### PR TITLE
Remove 64-bit generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,20 +57,18 @@ Generators using the [`random`][hackage-random] library:
 
 * `random-int`
 * `random-word32`
-* `random-word64`
-* `random-int-split`
 * `random-word32-split`
-* `random-word64-split`
-* `random-word64-splitsl`
-* `random-word64-splitsr`
-* `random-word64-splitsa`
+* `random-word32-splitsl`
+* `random-word32-splitsr`
+* `random-word32-splitsa`
 
 Generators using the [`splitmix`][hackage-splitmix] library:
 
 * `splitmix-word32`
 * `splitmix-word32-split`
-* `splitmix-word64`
-* `splitmix-word64-split`
+* `splitmix-word32-splitsl`
+* `splitmix-word32-splitsr`
+* `splitmix-word32-splitsa`
 
 # Tests
 
@@ -79,11 +77,11 @@ all of which accept a stream of random numbers on stdin:
 
 * [dieharder][]: run `dieharder -f stdin_input_raw -a` to execute all available
   tests (`-a`). See `dieharder -h` for more options.
-* [PractRand][]: run via `RNG_test stdin32` or `RNG_test stdin64` to test a
-  stream of 32-bit or 64-bit random numbers. See `RNG_test -help` for details.
-* [TestU01][]: run via `TestU01_stdin -[s|c|b]`. Note that TestU01 expects a
-  stream of 32-bit random numbers. Three test batteries are available: `-s`
-  starts SmallCrush, `-c` starts Crush, `-b` starts BigCrush.
+* [PractRand][]: run via `RNG_test stdin32` to test a stream of 32-bit random
+  numbers. See `RNG_test -help` for details.
+* [TestU01][]: run via `TestU01_stdin -[s|c|b]`, which expects a stream of
+  32-bit random numbers. Three test batteries are available: `-s` starts
+  SmallCrush, `-c` starts Crush, `-b` starts BigCrush.
 
 # Acknowledgements
 

--- a/generate/Main.hs
+++ b/generate/Main.hs
@@ -4,7 +4,7 @@ module Main where
 
 import Control.Monad (forever)
 import Data.IORef (newIORef, readIORef, writeIORef)
-import Data.Word (Word32, Word64)
+import Data.Word (Word32)
 import System.Environment (getArgs)
 
 import qualified Data.ByteString.Builder as BS
@@ -19,9 +19,6 @@ import qualified System.Random.SplitMix as SM
 
 randomInt :: R.RandomGen g => g -> (Int, g)
 randomInt = R.random
-
-random64 :: R.RandomGen g => g -> (Word64, g)
-random64 = R.random
 
 random32 :: R.RandomGen g => g -> (Word32, g)
 random32 = R.random
@@ -50,10 +47,6 @@ defaultSequenceWord32 ::
      R.RandomGen g => (g -> (Word32, g)) -> g -> (BS.Builder, g)
 defaultSequenceWord32 = defaultSequence BS.word32Host
 
-defaultSequenceWord64 ::
-     R.RandomGen g => (g -> (Word64, g)) -> g -> (BS.Builder, g)
-defaultSequenceWord64 = defaultSequence BS.word64Host
-
 -------------------------------------------------------------------------------
 -- Sequences of random numbers that use 'split'
 -------------------------------------------------------------------------------
@@ -78,15 +71,6 @@ splitSequence prim f gPrev =
           (prim BS.>*< prim BS.>*< prim BS.>*< prim)
           (fromIntegral rLL, (fromIntegral rLR, (fromIntegral rRL, fromIntegral rRR)))
       , gNext)
-
-splitSequenceWord64 :: R.RandomGen g => (g -> (Word64, g)) -> g -> (BS.Builder, g)
-splitSequenceWord64 = splitSequence BS.word64Host
-
-splitSequenceWord32 :: R.RandomGen g => (g -> (Word32, g)) -> g -> (BS.Builder, g)
-splitSequenceWord32 = splitSequence BS.word32Host
-
-splitSequenceWordInt :: R.RandomGen g => (g -> (Int, g)) -> g -> (BS.Builder, g)
-splitSequenceWordInt = splitSequence BS.word32Host
 
 -- | 'splitSequenceSL', 'splitSequenceSR' and 'splitSequenceSA' generate
 -- sequences that stress-test splittable RNGs, suggested here:
@@ -142,7 +126,7 @@ main = do
     ["random-word32"] ->
       spew stdout (R.mkStdGen 1337) (defaultSequenceWord32 random32)
     ["random-word32-split"] ->
-      spew stdout (R.mkStdGen 1337) (splitSequenceWord32 random32)
+      spew stdout (R.mkStdGen 1337) (splitSequence BS.word32Host random32)
     ["random-word32-splitsl"] ->
       spew stdout (R.mkStdGen 1337) (splitSequenceSL BS.word32Host random32)
     ["random-word32-splitsr"] ->
@@ -154,7 +138,7 @@ main = do
     ["splitmix-word32"] ->
       spew stdout (SM.mkSMGen 1337) (defaultSequenceWord32 SM.nextWord32)
     ["splitmix-word32-split"] ->
-      spew stdout (SM.mkSMGen 1337) (splitSequenceWord32 SM.nextWord32)
+      spew stdout (SM.mkSMGen 1337) (splitSequence BS.word32Host SM.nextWord32)
     ["splitmix-word32-splitsl"] ->
       spew stdout (SM.mkSMGen 1337) (splitSequenceSL BS.word32Host SM.nextWord32)
     ["splitmix-word32-splitsr"] ->

--- a/generate/Main.hs
+++ b/generate/Main.hs
@@ -141,27 +141,23 @@ main = do
       spew stdout (R.mkStdGen 1337) (defaultSequenceInt randomInt)
     ["random-word32"] ->
       spew stdout (R.mkStdGen 1337) (defaultSequenceWord32 random32)
-    ["random-word64"] ->
-      spew stdout (R.mkStdGen 1337) (defaultSequenceWord64 random64)
-    ["random-int-split"] ->
-      spew stdout (R.mkStdGen 1337) (splitSequenceWordInt randomInt)
     ["random-word32-split"] ->
       spew stdout (R.mkStdGen 1337) (splitSequenceWord32 random32)
-    ["random-word64-split"] ->
-      spew stdout (R.mkStdGen 1337) (splitSequence BS.word64Host random64)
-    ["random-word64-splitsl"] ->
-      spew stdout (R.mkStdGen 1337) (splitSequenceSL BS.word64Host random64)
-    ["random-word64-splitsr"] ->
-      spew stdout (R.mkStdGen 1337) (splitSequenceSR BS.word64Host random64)
-    ["random-word64-splitsa"] ->
-      spew stdout (R.mkStdGen 1337) (splitSequenceSA BS.word64Host random64)
+    ["random-word32-splitsl"] ->
+      spew stdout (R.mkStdGen 1337) (splitSequenceSL BS.word32Host random32)
+    ["random-word32-splitsr"] ->
+      spew stdout (R.mkStdGen 1337) (splitSequenceSR BS.word32Host random32)
+    ["random-word32-splitsa"] ->
+      spew stdout (R.mkStdGen 1337) (splitSequenceSA BS.word32Host random32)
 
     -- splitmix
     ["splitmix-word32"] ->
       spew stdout (SM.mkSMGen 1337) (defaultSequenceWord32 SM.nextWord32)
     ["splitmix-word32-split"] ->
       spew stdout (SM.mkSMGen 1337) (splitSequenceWord32 SM.nextWord32)
-    ["splitmix-word64"] ->
-      spew stdout (SM.mkSMGen 1337) (defaultSequenceWord64 SM.nextWord64)
-    ["splitmix-word64-split"] ->
-      spew stdout (SM.mkSMGen 1337) (splitSequenceWord64 SM.nextWord64)
+    ["splitmix-word32-splitsl"] ->
+      spew stdout (SM.mkSMGen 1337) (splitSequenceSL BS.word32Host SM.nextWord32)
+    ["splitmix-word32-splitsr"] ->
+      spew stdout (SM.mkSMGen 1337) (splitSequenceSR BS.word32Host SM.nextWord32)
+    ["splitmix-word32-splitsa"] ->
+      spew stdout (SM.mkSMGen 1337) (splitSequenceSA BS.word32Host SM.nextWord32)


### PR DESCRIPTION
If we have 32-bit and 64-bit generators using the same algorithm, they're extremely likely to either both pass or both fail the same tests. So let's cut down the number of generators.

I've removed the 64-bit versions here. I don't think it really matters which versions are removed - the argument in favour of keeping 32-bit versions is that TestU01 operates on 32-bit random numbers.