### PR TITLE
Add first test results: split sequences for `random`

### DIFF
--- a/results/README.md
+++ b/results/README.md
@@ -1,0 +1,6 @@
+# Test results
+
+This folder contains test results. Each result file contains the command run as
+well as the commit hash of this repository from which it was run, to get
+maximum reproducibility.
+

--- a/results/random-word32-split-practrand-1gb
+++ b/results/random-word32-split-practrand-1gb
@@ -1,0 +1,33 @@
++ git rev-parse HEAD
+782b6d95e02833084d03633ea11286e90542f734
++ generate random-word32-split
++ RNG_test stdin32 -tlmax 1GB
+RNG_test using PractRand version 0.93
+RNG = RNG_stdin32, seed = 0x53d2217e
+test set = normal, folding = standard (32 bit)
+
+rng=RNG_stdin32, seed=0x53d2217e
+length= 8 megabytes (2^23 bytes), time= 2.1 seconds
+  Test Name                         Raw       Processed     Evaluation
+  BCFN(2+0,13-5,T)                  R=+159.4  p =  1.3e-62    FAIL !!!!      
+  BCFN(2+1,13-5,T)                  R= +72.7  p =  1.1e-28    FAIL !!!       
+  DC6-9x1Bytes-1                    R=+222.7  p =  1.6e-117   FAIL !!!!!     
+  [Low8/32]DC6-9x1Bytes-1           R= +72.5  p =  3.3e-42    FAIL !!!       
+  [Low1/32]BCFN(2+0,13-8,T)         R=  +9.5  p =  2.7e-3   unusual          
+  [Low1/32]DC6-9x1Bytes-1           R=+456.6  p =  4.2e-264   FAIL !!!!!!    
+  [Low1/32]Gap-16:A                 R=+323.9  p =  4.0e-259   FAIL !!!!!!    
+  [Low1/32]Gap-16:B                 R=+837.6  p =  6.1e-650   FAIL !!!!!!!   
+  [Low1/32]FPF-14+6/16:(0,14-5)     R= +1256  p =  4e-1041    FAIL !!!!!!!!  
+  [Low1/32]FPF-14+6/16:(1,14-6)     R=+890.0  p =  4.2e-681   FAIL !!!!!!!   
+  [Low1/32]FPF-14+6/16:(2,14-7)     R=+201.8  p =  1.8e-160   FAIL !!!!!     
+  [Low1/32]FPF-14+6/16:(3,14-8)     R=+294.5  p =  5.9e-212   FAIL !!!!!!    
+  [Low1/32]FPF-14+6/16:(4,14-8)     R=+319.2  p =  9.0e-230   FAIL !!!!!!    
+  [Low1/32]FPF-14+6/16:(5,14-9)     R=+215.2  p =  8.9e-136   FAIL !!!!!     
+  [Low1/32]FPF-14+6/16:(6,14-10)    R= +46.0  p =  4.9e-25    FAIL !!        
+  [Low1/32]FPF-14+6/16:(7,14-11)    R= +75.8  p =  7.0e-34    FAIL !!!       
+  [Low1/32]FPF-14+6/16:(8,14-11)    R= +54.0  p =  2.2e-24    FAIL !!        
+  [Low1/32]FPF-14+6/16:all          R= +1776  p =  1e-1450    FAIL !!!!!!!!  
+  [Low1/32]FPF-14+6/16:all2         R=+666613 p = 0           FAIL !!!!!!!!  
+  [Low1/32]FPF-14+6/16:cross        R= +1575  p =  3e-1130    FAIL !!!!!!!!  
+  ...and 64 test result(s) without anomalies
+

--- a/results/random-word32-split-testu01-smallcrush
+++ b/results/random-word32-split-testu01-smallcrush
@@ -1,0 +1,355 @@
++ git rev-parse HEAD
+18b4efbc1e49057b6fd49b16e253af15160cd335
++ generate random-word32-split
++ TestU01_stdin -s
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+                 Starting SmallCrush
+                 Version: TestU01 1.2.3
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_BirthdaySpacings test:
+-----------------------------------------------
+   N =  1,  n = 5000000,  r =  0,    d = 1073741824,    t = 2,    p = 1
+
+
+      Number of cells = d^t = 1152921504606846976
+      Lambda = Poisson mean =      27.1051
+
+
+----------------------------------------------------
+Total expected number = N*Lambda      :      27.11
+Total observed number                 :      16
+p-value of test                       :    0.98
+
+
+-----------------------------------------------
+CPU time used                    :  00:00:02.50
+
+Generator state:
+
+
+
+
+***********************************************************
+Test sknuth_Collision calling smultin_Multinomial
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smultin_Multinomial test:
+-----------------------------------------------
+   N =  1,  n = 5000000,  r =  0,   d = 65536,   t =  2,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =         4294967296
+       Expected number per cell =  1 /  858.99346
+       EColl = n^2 / (2k) =  2910.383046
+       Hashing =   TRUE
+
+       Collision test,    Mu =      2909.2534,    Sigma =    53.8957
+
+-----------------------------------------------
+Test Results for Collisions
+
+Expected number of collisions = Mu    :     2909.25
+Observed number of collisions         :     2878
+p-value of test                       :    0.72
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :       4289970174
+  j =  1                              :          4994244
+  j =  2                              :             2878
+  j =  3                              :                0
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:00:02.23
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_Gap test:
+-----------------------------------------------
+   N =  1,  n = 200000,  r = 22,   Alpha =        0,   Beta  = 0.00390625
+
+
+-----------------------------------------------
+Number of degrees of freedom          : 1114
+Chi-square statistic                  : 1167.17
+p-value of test                       :    0.13
+
+-----------------------------------------------
+CPU time used                    :  00:00:03.28
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_SimpPoker test:
+-----------------------------------------------
+   N =  1,  n = 400000,  r = 24,   d =   64,   k =   64
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   19
+Chi-square statistic                  :  655.13
+p-value of test                       :   eps      *****
+
+-----------------------------------------------
+CPU time used                    :  00:00:02.06
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_CouponCollector test:
+-----------------------------------------------
+   N =  1,  n = 500000,  r = 26,   d =   16
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   44
+Chi-square statistic                  : 1209.75
+p-value of test                       :   eps      *****
+
+-----------------------------------------------
+CPU time used                    :  00:00:01.83
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_MaxOft test:
+-----------------------------------------------
+   N =  1,  n = 2000000,  r =  0,   d = 100000,   t =  6
+
+      Number of categories = 100000
+      Expected number per category  = 20.00
+
+
+-----------------------------------------------
+Number of degrees of freedom          : 99999
+Chi-square statistic                  : 1.10e+5
+p-value of test                       :   eps      *****
+
+
+-----------------------------------------------
+Anderson-Darling statistic            :   0.000
+p-value of test                       : 1 - eps1    *****
+
+
+-----------------------------------------------
+CPU time used                    :  00:00:02.24
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+svaria_WeightDistrib test:
+-----------------------------------------------
+   N =  1,  n = 200000,  r = 27,  k = 256,  Alpha =      0,  Beta =  0.125
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   41
+Chi-square statistic                  :  251.62
+p-value of test                       :   eps      *****
+
+-----------------------------------------------
+CPU time used                    :  00:00:03.28
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_MatrixRank test:
+-----------------------------------------------
+   N =  1,  n = 20000,  r = 20,    s = 10,    L = 60,    k = 60
+
+
+-----------------------------------------------
+Number of degrees of freedom          :    3
+Chi-square statistic                  :   13.86
+p-value of test                       :  3.1e-3
+
+-----------------------------------------------
+CPU time used                    :  00:00:01.39
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_HammingIndep test:
+-----------------------------------------------
+   N =  1,  n = 500000,  r = 20,   s = 10,   L = 300,   d = 0
+
+
+
+Counters with expected numbers >= 10
+-----------------------------------------------
+Number of degrees of freedom          : 2209
+Chi-square statistic                  : 2692.06
+p-value of test                       : 5.0e-12    *****
+
+-----------------------------------------------
+CPU time used                    :  00:00:02.58
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+swalk_RandomWalk1 test:
+-----------------------------------------------
+   N =  1,  n = 1000000,  r =  0,   s = 30,   L0 =  150,   L1 =  150
+
+
+
+-----------------------------------------------
+Test on the values of the Statistic H
+
+Number of degrees of freedom          :   52
+ChiSquare statistic                   :  580.13
+p-value of test                       :   eps      *****
+
+
+-----------------------------------------------
+Test on the values of the Statistic M
+
+Number of degrees of freedom          :   52
+ChiSquare statistic                   :  584.69
+p-value of test                       :   eps      *****
+
+
+-----------------------------------------------
+Test on the values of the Statistic J
+
+Number of degrees of freedom          :   75
+ChiSquare statistic                   :  273.47
+p-value of test                       :   eps      *****
+
+
+-----------------------------------------------
+Test on the values of the Statistic R
+
+Number of degrees of freedom          :   44
+ChiSquare statistic                   :  136.21
+p-value of test                       : 2.3e-11    *****
+
+
+-----------------------------------------------
+Test on the values of the Statistic C
+
+Number of degrees of freedom          :   26
+ChiSquare statistic                   :  108.85
+p-value of test                       : 4.2e-12    *****
+
+
+-----------------------------------------------
+CPU time used                    :  00:00:01.96
+
+Generator state:
+
+
+
+
+
+========= Summary results of SmallCrush =========
+
+ Version:          TestU01 1.2.3
+ Generator:        32-bit stdin
+ Number of statistics:  15
+ Total CPU time:   00:00:23.41
+ The following tests gave p-values outside [0.001, 0.9990]:
+ (eps  means a value < 1.0e-300):
+ (eps1 means a value < 1.0e-15):
+
+       Test                          p-value
+ ----------------------------------------------
+  4  SimpPoker                        eps  
+  5  CouponCollector                  eps  
+  6  MaxOft                           eps  
+  6  MaxOft AD                      1 - eps1
+  7  WeightDistrib                    eps  
+  9  HammingIndep                   5.0e-12
+ 10  RandomWalk1 H                    eps  
+ 10  RandomWalk1 M                    eps  
+ 10  RandomWalk1 J                    eps  
+ 10  RandomWalk1 R                  2.3e-11
+ 10  RandomWalk1 C                  4.2e-12
+ ----------------------------------------------
+ All other tests were passed
+
+
+
+Total processed 32Bit Samples =        226688795

--- a/results/random-word32-splita-practrand-1gb
+++ b/results/random-word32-splita-practrand-1gb
@@ -1,0 +1,43 @@
++ git rev-parse HEAD
+782b6d95e02833084d03633ea11286e90542f734
++ generate random-word32-splita
++ RNG_test stdin32 -tlmax 1GB
+RNG_test using PractRand version 0.93
+RNG = RNG_stdin32, seed = 0xf512eb15
+test set = normal, folding = standard (32 bit)
+
+rng=RNG_stdin32, seed=0xf512eb15
+length= 8 megabytes (2^23 bytes), time= 2.5 seconds
+  no anomalies in 84 test result(s)
+
+rng=RNG_stdin32, seed=0xf512eb15
+length= 16 megabytes (2^24 bytes), time= 5.4 seconds
+  Test Name                         Raw       Processed     Evaluation
+  DC6-9x1Bytes-1                    R=  +5.6  p =  6.1e-3   unusual          
+  ...and 92 test result(s) without anomalies
+
+rng=RNG_stdin32, seed=0xf512eb15
+length= 32 megabytes (2^25 bytes), time= 11.1 seconds
+  no anomalies in 100 test result(s)
+
+rng=RNG_stdin32, seed=0xf512eb15
+length= 64 megabytes (2^26 bytes), time= 21.0 seconds
+  no anomalies in 108 test result(s)
+
+rng=RNG_stdin32, seed=0xf512eb15
+length= 128 megabytes (2^27 bytes), time= 41.3 seconds
+  Test Name                         Raw       Processed     Evaluation
+  FPF-14+6/16:all                   R=  +4.4  p =  1.4e-3   unusual          
+  ...and 116 test result(s) without anomalies
+
+rng=RNG_stdin32, seed=0xf512eb15
+length= 256 megabytes (2^28 bytes), time= 77.6 seconds
+  no anomalies in 124 test result(s)
+
+rng=RNG_stdin32, seed=0xf512eb15
+length= 512 megabytes (2^29 bytes), time= 155 seconds
+  no anomalies in 132 test result(s)
+
+rng=RNG_stdin32, seed=0xf512eb15
+length= 1 gigabyte (2^30 bytes), time= 300 seconds
+  no anomalies in 141 test result(s)

--- a/results/random-word32-splita-testu01-smallcrush
+++ b/results/random-word32-splita-testu01-smallcrush
@@ -1,0 +1,339 @@
++ git rev-parse HEAD
+18b4efbc1e49057b6fd49b16e253af15160cd335
++ generate random-word32-splita
++ TestU01_stdin -s
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+                 Starting SmallCrush
+                 Version: TestU01 1.2.3
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_BirthdaySpacings test:
+-----------------------------------------------
+   N =  1,  n = 5000000,  r =  0,    d = 1073741824,    t = 2,    p = 1
+
+
+      Number of cells = d^t = 1152921504606846976
+      Lambda = Poisson mean =      27.1051
+
+
+----------------------------------------------------
+Total expected number = N*Lambda      :      27.11
+Total observed number                 :      21
+p-value of test                       :    0.86
+
+
+-----------------------------------------------
+CPU time used                    :  00:00:02.48
+
+Generator state:
+
+
+
+
+***********************************************************
+Test sknuth_Collision calling smultin_Multinomial
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smultin_Multinomial test:
+-----------------------------------------------
+   N =  1,  n = 5000000,  r =  0,   d = 65536,   t =  2,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =         4294967296
+       Expected number per cell =  1 /  858.99346
+       EColl = n^2 / (2k) =  2910.383046
+       Hashing =   TRUE
+
+       Collision test,    Mu =      2909.2534,    Sigma =    53.8957
+
+-----------------------------------------------
+Test Results for Collisions
+
+Expected number of collisions = Mu    :     2909.25
+Observed number of collisions         :     2884
+p-value of test                       :    0.68
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :       4289970180
+  j =  1                              :          4994234
+  j =  2                              :             2880
+  j =  3                              :                2
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:00:02.50
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_Gap test:
+-----------------------------------------------
+   N =  1,  n = 200000,  r = 22,   Alpha =        0,   Beta  = 0.00390625
+
+
+-----------------------------------------------
+Number of degrees of freedom          : 1114
+Chi-square statistic                  : 1044.10
+p-value of test                       :    0.93
+
+-----------------------------------------------
+CPU time used                    :  00:00:03.31
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_SimpPoker test:
+-----------------------------------------------
+   N =  1,  n = 400000,  r = 24,   d =   64,   k =   64
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   19
+Chi-square statistic                  :   20.47
+p-value of test                       :    0.37
+
+-----------------------------------------------
+CPU time used                    :  00:00:02.14
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_CouponCollector test:
+-----------------------------------------------
+   N =  1,  n = 500000,  r = 26,   d =   16
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   44
+Chi-square statistic                  :   49.63
+p-value of test                       :    0.26
+
+-----------------------------------------------
+CPU time used                    :  00:00:01.82
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_MaxOft test:
+-----------------------------------------------
+   N =  1,  n = 2000000,  r =  0,   d = 100000,   t =  6
+
+      Number of categories = 100000
+      Expected number per category  = 20.00
+
+
+-----------------------------------------------
+Number of degrees of freedom          : 99999
+Chi-square statistic                  :99960.50
+p-value of test                       :    0.53
+
+
+-----------------------------------------------
+Anderson-Darling statistic            :    0.67
+p-value of test                       :    0.33
+
+
+-----------------------------------------------
+CPU time used                    :  00:00:02.02
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+svaria_WeightDistrib test:
+-----------------------------------------------
+   N =  1,  n = 200000,  r = 27,  k = 256,  Alpha =      0,  Beta =  0.125
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   41
+Chi-square statistic                  :   37.48
+p-value of test                       :    0.63
+
+-----------------------------------------------
+CPU time used                    :  00:00:03.14
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_MatrixRank test:
+-----------------------------------------------
+   N =  1,  n = 20000,  r = 20,    s = 10,    L = 60,    k = 60
+
+
+-----------------------------------------------
+Number of degrees of freedom          :    3
+Chi-square statistic                  :    3.15
+p-value of test                       :    0.37
+
+-----------------------------------------------
+CPU time used                    :  00:00:01.46
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_HammingIndep test:
+-----------------------------------------------
+   N =  1,  n = 500000,  r = 20,   s = 10,   L = 300,   d = 0
+
+
+
+Counters with expected numbers >= 10
+-----------------------------------------------
+Number of degrees of freedom          : 2209
+Chi-square statistic                  : 2272.64
+p-value of test                       :    0.17
+
+-----------------------------------------------
+CPU time used                    :  00:00:02.51
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+swalk_RandomWalk1 test:
+-----------------------------------------------
+   N =  1,  n = 1000000,  r =  0,   s = 30,   L0 =  150,   L1 =  150
+
+
+
+-----------------------------------------------
+Test on the values of the Statistic H
+
+Number of degrees of freedom          :   52
+ChiSquare statistic                   :   41.53
+p-value of test                       :    0.85
+
+
+-----------------------------------------------
+Test on the values of the Statistic M
+
+Number of degrees of freedom          :   52
+ChiSquare statistic                   :   53.43
+p-value of test                       :    0.42
+
+
+-----------------------------------------------
+Test on the values of the Statistic J
+
+Number of degrees of freedom          :   75
+ChiSquare statistic                   :   81.24
+p-value of test                       :    0.29
+
+
+-----------------------------------------------
+Test on the values of the Statistic R
+
+Number of degrees of freedom          :   44
+ChiSquare statistic                   :   41.44
+p-value of test                       :    0.58
+
+
+-----------------------------------------------
+Test on the values of the Statistic C
+
+Number of degrees of freedom          :   26
+ChiSquare statistic                   :   28.48
+p-value of test                       :    0.34
+
+
+-----------------------------------------------
+CPU time used                    :  00:00:01.82
+
+Generator state:
+
+
+
+
+
+========= Summary results of SmallCrush =========
+
+ Version:          TestU01 1.2.3
+ Generator:        32-bit stdin
+ Number of statistics:  15
+ Total CPU time:   00:00:23.25
+
+ All tests were passed
+
+
+
+Total processed 32Bit Samples =        226770875
+

--- a/results/random-word32-splitl-practrand-1gb
+++ b/results/random-word32-splitl-practrand-1gb
@@ -1,0 +1,42 @@
++ git rev-parse HEAD
+782b6d95e02833084d03633ea11286e90542f734
++ generate random-word32-splitl
++ RNG_test stdin32 -tlmax 1GB
+RNG_test using PractRand version 0.93
+RNG = RNG_stdin32, seed = 0xffa392f3
+test set = normal, folding = standard (32 bit)
+
+rng=RNG_stdin32, seed=0xffa392f3
+length= 8 megabytes (2^23 bytes), time= 2.1 seconds
+  no anomalies in 84 test result(s)
+
+rng=RNG_stdin32, seed=0xffa392f3
+length= 16 megabytes (2^24 bytes), time= 5.8 seconds
+  Test Name                         Raw       Processed     Evaluation
+  [Low1/32]FPF-14+6/16:cross        R=  +4.5  p =  6.7e-4   unusual          
+  ...and 92 test result(s) without anomalies
+
+rng=RNG_stdin32, seed=0xffa392f3
+length= 32 megabytes (2^25 bytes), time= 10.5 seconds
+  no anomalies in 100 test result(s)
+
+rng=RNG_stdin32, seed=0xffa392f3
+length= 64 megabytes (2^26 bytes), time= 19.4 seconds
+  no anomalies in 108 test result(s)
+
+rng=RNG_stdin32, seed=0xffa392f3
+length= 128 megabytes (2^27 bytes), time= 40.2 seconds
+  no anomalies in 117 test result(s)
+
+rng=RNG_stdin32, seed=0xffa392f3
+length= 256 megabytes (2^28 bytes), time= 76.4 seconds
+  no anomalies in 124 test result(s)
+
+rng=RNG_stdin32, seed=0xffa392f3
+length= 512 megabytes (2^29 bytes), time= 151 seconds
+  no anomalies in 132 test result(s)
+
+rng=RNG_stdin32, seed=0xffa392f3
+length= 1 gigabyte (2^30 bytes), time= 302 seconds
+  no anomalies in 141 test result(s)
+

--- a/results/random-word32-splitl-testu01-smallcrush
+++ b/results/random-word32-splitl-testu01-smallcrush
@@ -1,0 +1,338 @@
++ git rev-parse HEAD
+18b4efbc1e49057b6fd49b16e253af15160cd335
++ generate random-word32-splitl
++ TestU01_stdin -s
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+                 Starting SmallCrush
+                 Version: TestU01 1.2.3
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_BirthdaySpacings test:
+-----------------------------------------------
+   N =  1,  n = 5000000,  r =  0,    d = 1073741824,    t = 2,    p = 1
+
+
+      Number of cells = d^t = 1152921504606846976
+      Lambda = Poisson mean =      27.1051
+
+
+----------------------------------------------------
+Total expected number = N*Lambda      :      27.11
+Total observed number                 :      13
+p-value of test                       :    0.9979
+
+
+-----------------------------------------------
+CPU time used                    :  00:00:02.56
+
+Generator state:
+
+
+
+
+***********************************************************
+Test sknuth_Collision calling smultin_Multinomial
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smultin_Multinomial test:
+-----------------------------------------------
+   N =  1,  n = 5000000,  r =  0,   d = 65536,   t =  2,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =         4294967296
+       Expected number per cell =  1 /  858.99346
+       EColl = n^2 / (2k) =  2910.383046
+       Hashing =   TRUE
+
+       Collision test,    Mu =      2909.2534,    Sigma =    53.8957
+
+-----------------------------------------------
+Test Results for Collisions
+
+Expected number of collisions = Mu    :     2909.25
+Observed number of collisions         :     2867
+p-value of test                       :    0.78
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :       4289970163
+  j =  1                              :          4994270
+  j =  2                              :             2859
+  j =  3                              :                4
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:00:02.55
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_Gap test:
+-----------------------------------------------
+   N =  1,  n = 200000,  r = 22,   Alpha =        0,   Beta  = 0.00390625
+
+
+-----------------------------------------------
+Number of degrees of freedom          : 1114
+Chi-square statistic                  : 1088.18
+p-value of test                       :    0.70
+
+-----------------------------------------------
+CPU time used                    :  00:00:03.33
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_SimpPoker test:
+-----------------------------------------------
+   N =  1,  n = 400000,  r = 24,   d =   64,   k =   64
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   19
+Chi-square statistic                  :   16.81
+p-value of test                       :    0.60
+
+-----------------------------------------------
+CPU time used                    :  00:00:02.00
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_CouponCollector test:
+-----------------------------------------------
+   N =  1,  n = 500000,  r = 26,   d =   16
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   44
+Chi-square statistic                  :   37.38
+p-value of test                       :    0.75
+
+-----------------------------------------------
+CPU time used                    :  00:00:01.88
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_MaxOft test:
+-----------------------------------------------
+   N =  1,  n = 2000000,  r =  0,   d = 100000,   t =  6
+
+      Number of categories = 100000
+      Expected number per category  = 20.00
+
+
+-----------------------------------------------
+Number of degrees of freedom          : 99999
+Chi-square statistic                  :99328.00
+p-value of test                       :    0.93
+
+
+-----------------------------------------------
+Anderson-Darling statistic            :    0.60
+p-value of test                       :    0.40
+
+
+-----------------------------------------------
+CPU time used                    :  00:00:02.08
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+svaria_WeightDistrib test:
+-----------------------------------------------
+   N =  1,  n = 200000,  r = 27,  k = 256,  Alpha =      0,  Beta =  0.125
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   41
+Chi-square statistic                  :   42.74
+p-value of test                       :    0.40
+
+-----------------------------------------------
+CPU time used                    :  00:00:03.28
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_MatrixRank test:
+-----------------------------------------------
+   N =  1,  n = 20000,  r = 20,    s = 10,    L = 60,    k = 60
+
+
+-----------------------------------------------
+Number of degrees of freedom          :    3
+Chi-square statistic                  :    0.64
+p-value of test                       :    0.89
+
+-----------------------------------------------
+CPU time used                    :  00:00:01.35
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_HammingIndep test:
+-----------------------------------------------
+   N =  1,  n = 500000,  r = 20,   s = 10,   L = 300,   d = 0
+
+
+
+Counters with expected numbers >= 10
+-----------------------------------------------
+Number of degrees of freedom          : 2209
+Chi-square statistic                  : 2119.79
+p-value of test                       :    0.91
+
+-----------------------------------------------
+CPU time used                    :  00:00:02.53
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+swalk_RandomWalk1 test:
+-----------------------------------------------
+   N =  1,  n = 1000000,  r =  0,   s = 30,   L0 =  150,   L1 =  150
+
+
+
+-----------------------------------------------
+Test on the values of the Statistic H
+
+Number of degrees of freedom          :   52
+ChiSquare statistic                   :   71.76
+p-value of test                       :    0.04
+
+
+-----------------------------------------------
+Test on the values of the Statistic M
+
+Number of degrees of freedom          :   52
+ChiSquare statistic                   :   63.22
+p-value of test                       :    0.14
+
+
+-----------------------------------------------
+Test on the values of the Statistic J
+
+Number of degrees of freedom          :   75
+ChiSquare statistic                   :   73.38
+p-value of test                       :    0.53
+
+
+-----------------------------------------------
+Test on the values of the Statistic R
+
+Number of degrees of freedom          :   44
+ChiSquare statistic                   :   37.76
+p-value of test                       :    0.73
+
+
+-----------------------------------------------
+Test on the values of the Statistic C
+
+Number of degrees of freedom          :   26
+ChiSquare statistic                   :   40.65
+p-value of test                       :    0.03
+
+
+-----------------------------------------------
+CPU time used                    :  00:00:01.82
+
+Generator state:
+
+
+
+
+
+========= Summary results of SmallCrush =========
+
+ Version:          TestU01 1.2.3
+ Generator:        32-bit stdin
+ Number of statistics:  15
+ Total CPU time:   00:00:23.44
+
+ All tests were passed
+
+
+
+Total processed 32Bit Samples =        226693150

--- a/results/random-word32-splitr-practrand-1gb
+++ b/results/random-word32-splitr-practrand-1gb
@@ -1,0 +1,41 @@
++ git rev-parse HEAD
+782b6d95e02833084d03633ea11286e90542f734
++ RNG_test stdin32 -tlmax 1GB
++ generate random-word32-splitr
+RNG_test using PractRand version 0.93
+RNG = RNG_stdin32, seed = 0xeb53794f
+test set = normal, folding = standard (32 bit)
+
+rng=RNG_stdin32, seed=0xeb53794f
+length= 8 megabytes (2^23 bytes), time= 2.5 seconds
+  no anomalies in 84 test result(s)
+
+rng=RNG_stdin32, seed=0xeb53794f
+length= 16 megabytes (2^24 bytes), time= 5.6 seconds
+  no anomalies in 93 test result(s)
+
+rng=RNG_stdin32, seed=0xeb53794f
+length= 32 megabytes (2^25 bytes), time= 10.9 seconds
+  no anomalies in 100 test result(s)
+
+rng=RNG_stdin32, seed=0xeb53794f
+length= 64 megabytes (2^26 bytes), time= 21.0 seconds
+  Test Name                         Raw       Processed     Evaluation
+  [Low8/32]DC6-9x1Bytes-1           R=  +5.9  p =  4.2e-3   unusual          
+  ...and 107 test result(s) without anomalies
+
+rng=RNG_stdin32, seed=0xeb53794f
+length= 128 megabytes (2^27 bytes), time= 38.8 seconds
+  no anomalies in 117 test result(s)
+
+rng=RNG_stdin32, seed=0xeb53794f
+length= 256 megabytes (2^28 bytes), time= 75.8 seconds
+  no anomalies in 124 test result(s)
+
+rng=RNG_stdin32, seed=0xeb53794f
+length= 512 megabytes (2^29 bytes), time= 152 seconds
+  no anomalies in 132 test result(s)
+
+rng=RNG_stdin32, seed=0xeb53794f
+length= 1 gigabyte (2^30 bytes), time= 299 seconds
+  no anomalies in 141 test result(s)

--- a/results/random-word32-splitr-testu01-smallcrush
+++ b/results/random-word32-splitr-testu01-smallcrush
@@ -1,0 +1,345 @@
++ git rev-parse HEAD
+18b4efbc1e49057b6fd49b16e253af15160cd335
++ TestU01_stdin -s
++ generate random-word32-splitr
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+                 Starting SmallCrush
+                 Version: TestU01 1.2.3
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_BirthdaySpacings test:
+-----------------------------------------------
+   N =  1,  n = 5000000,  r =  0,    d = 1073741824,    t = 2,    p = 1
+
+
+      Number of cells = d^t = 1152921504606846976
+      Lambda = Poisson mean =      27.1051
+
+
+----------------------------------------------------
+Total expected number = N*Lambda      :      27.11
+Total observed number                 :      49
+p-value of test                       :  9.8e-5    *****
+
+
+-----------------------------------------------
+CPU time used                    :  00:00:02.31
+
+Generator state:
+
+
+
+
+***********************************************************
+Test sknuth_Collision calling smultin_Multinomial
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smultin_Multinomial test:
+-----------------------------------------------
+   N =  1,  n = 5000000,  r =  0,   d = 65536,   t =  2,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =         4294967296
+       Expected number per cell =  1 /  858.99346
+       EColl = n^2 / (2k) =  2910.383046
+       Hashing =   TRUE
+
+       Collision test,    Mu =      2909.2534,    Sigma =    53.8957
+
+-----------------------------------------------
+Test Results for Collisions
+
+Expected number of collisions = Mu    :     2909.25
+Observed number of collisions         :     2886
+p-value of test                       :    0.66
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :       4289970182
+  j =  1                              :          4994229
+  j =  2                              :             2884
+  j =  3                              :                1
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:00:02.26
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_Gap test:
+-----------------------------------------------
+   N =  1,  n = 200000,  r = 22,   Alpha =        0,   Beta  = 0.00390625
+
+
+-----------------------------------------------
+Number of degrees of freedom          : 1114
+Chi-square statistic                  : 1138.39
+p-value of test                       :    0.30
+
+-----------------------------------------------
+CPU time used                    :  00:00:03.34
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_SimpPoker test:
+-----------------------------------------------
+   N =  1,  n = 400000,  r = 24,   d =   64,   k =   64
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   19
+Chi-square statistic                  :   13.19
+p-value of test                       :    0.83
+
+-----------------------------------------------
+CPU time used                    :  00:00:02.05
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_CouponCollector test:
+-----------------------------------------------
+   N =  1,  n = 500000,  r = 26,   d =   16
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   44
+Chi-square statistic                  :   35.50
+p-value of test                       :    0.82
+
+-----------------------------------------------
+CPU time used                    :  00:00:01.78
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_MaxOft test:
+-----------------------------------------------
+   N =  1,  n = 2000000,  r =  0,   d = 100000,   t =  6
+
+      Number of categories = 100000
+      Expected number per category  = 20.00
+
+
+-----------------------------------------------
+Number of degrees of freedom          : 99999
+Chi-square statistic                  : 1.00e+5
+p-value of test                       :    0.20
+
+
+-----------------------------------------------
+Anderson-Darling statistic            :    0.66
+p-value of test                       :    0.34
+
+
+-----------------------------------------------
+CPU time used                    :  00:00:02.07
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+svaria_WeightDistrib test:
+-----------------------------------------------
+   N =  1,  n = 200000,  r = 27,  k = 256,  Alpha =      0,  Beta =  0.125
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   41
+Chi-square statistic                  :   33.07
+p-value of test                       :    0.81
+
+-----------------------------------------------
+CPU time used                    :  00:00:03.30
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_MatrixRank test:
+-----------------------------------------------
+   N =  1,  n = 20000,  r = 20,    s = 10,    L = 60,    k = 60
+
+
+-----------------------------------------------
+Number of degrees of freedom          :    3
+Chi-square statistic                  :    3.96
+p-value of test                       :    0.27
+
+-----------------------------------------------
+CPU time used                    :  00:00:01.39
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_HammingIndep test:
+-----------------------------------------------
+   N =  1,  n = 500000,  r = 20,   s = 10,   L = 300,   d = 0
+
+
+
+Counters with expected numbers >= 10
+-----------------------------------------------
+Number of degrees of freedom          : 2209
+Chi-square statistic                  : 2280.50
+p-value of test                       :    0.14
+
+-----------------------------------------------
+CPU time used                    :  00:00:02.53
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+swalk_RandomWalk1 test:
+-----------------------------------------------
+   N =  1,  n = 1000000,  r =  0,   s = 30,   L0 =  150,   L1 =  150
+
+
+
+-----------------------------------------------
+Test on the values of the Statistic H
+
+Number of degrees of freedom          :   52
+ChiSquare statistic                   :   46.14
+p-value of test                       :    0.70
+
+
+-----------------------------------------------
+Test on the values of the Statistic M
+
+Number of degrees of freedom          :   52
+ChiSquare statistic                   :   59.32
+p-value of test                       :    0.23
+
+
+-----------------------------------------------
+Test on the values of the Statistic J
+
+Number of degrees of freedom          :   75
+ChiSquare statistic                   :   54.70
+p-value of test                       :    0.96
+
+
+-----------------------------------------------
+Test on the values of the Statistic R
+
+Number of degrees of freedom          :   44
+ChiSquare statistic                   :   39.93
+p-value of test                       :    0.65
+
+
+-----------------------------------------------
+Test on the values of the Statistic C
+
+Number of degrees of freedom          :   26
+ChiSquare statistic                   :   20.02
+p-value of test                       :    0.79
+
+
+-----------------------------------------------
+CPU time used                    :  00:00:01.78
+
+Generator state:
+
+
+
+
+
+========= Summary results of SmallCrush =========
+
+ Version:          TestU01 1.2.3
+ Generator:        32-bit stdin
+ Number of statistics:  15
+ Total CPU time:   00:00:22.85
+ The following tests gave p-values outside [0.001, 0.9990]:
+ (eps  means a value < 1.0e-300):
+ (eps1 means a value < 1.0e-15):
+
+       Test                          p-value
+ ----------------------------------------------
+  1  BirthdaySpacings                9.8e-5
+ ----------------------------------------------
+ All other tests were passed
+
+
+
+Total processed 32Bit Samples =        226694499

--- a/results/splitmix-word32-testu01-bigcrush
+++ b/results/splitmix-word32-testu01-bigcrush
@@ -1,0 +1,3790 @@
+git rev-parse HEAD
+18b4efbc1e49057b6fd49b16e253af15160cd335
+time generate splitmix-word32 | TestU01_stdin -b
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+                 Starting BigCrush
+                 Version: TestU01 1.2.3
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+***********************************************************
+Test smarsa_SerialOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N =  1,  n = 1000000000,  r =  0,   d =  256,   t =  3,
+       Sparse =  FALSE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =           16777216
+       Expected number per cell =   59.604645
+       Hashing =  FALSE
+
+   For Delta > -1, we use the ChiSquare approximation
+   Correction factor of the ChiSquare: 
+       Delta =     1,    Mu =   0.0083558402,    Sigma =          1
+
+-----------------------------------------------
+Test Results for Delta =   1.0000
+
+Number of degrees of freedom          : 16711680
+Value of the statistic                : 1.67e+7
+p-value of test                       :    0.25
+
+
+-----------------------------------------------
+CPU time used                    :  00:03:09.96
+
+Generator state:
+
+
+
+
+***********************************************************
+Test smarsa_SerialOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N =  1,  n = 1000000000,  r = 22,   d =  256,   t =  3,
+       Sparse =  FALSE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =           16777216
+       Expected number per cell =   59.604645
+       Hashing =  FALSE
+
+   For Delta > -1, we use the ChiSquare approximation
+   Correction factor of the ChiSquare: 
+       Delta =     1,    Mu =   0.0083558402,    Sigma =          1
+
+-----------------------------------------------
+Test Results for Delta =   1.0000
+
+Number of degrees of freedom          : 16711680
+Value of the statistic                : 1.67e+7
+p-value of test                       :    0.11
+
+
+-----------------------------------------------
+CPU time used                    :  00:03:29.56
+
+Generator state:
+
+
+
+
+***********************************************************
+Test smarsa_CollisionOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N = 30,  n = 20000000,  r =  0,   d = 2097152,   t =  2,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =      4398046511104
+       Expected number per cell =  1 /  219902.33
+       EColl = n^2 / (2k) =  45.47473509
+       Hashing =   TRUE
+
+       Collision test
+
+       CollisionOver:   density = n / k =  1 /  219902.33
+       Expected number of collisions = Mu =      45.47
+
+
+-----------------------------------------------
+Results of CollisionOver test:
+
+POISSON approximation                 :
+Expected number of collisions = N*Mu  :     1364.24
+Observed number of collisions         :     1412
+p-value of test                       :    0.10
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :  131940795334532
+  j =  1                              :        599997176
+  j =  2                              :             1412
+  j =  3                              :                0
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:05:28.83
+
+Generator state:
+
+
+
+
+***********************************************************
+Test smarsa_CollisionOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N = 30,  n = 20000000,  r =  9,   d = 2097152,   t =  2,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =      4398046511104
+       Expected number per cell =  1 /  219902.33
+       EColl = n^2 / (2k) =  45.47473509
+       Hashing =   TRUE
+
+       Collision test
+
+       CollisionOver:   density = n / k =  1 /  219902.33
+       Expected number of collisions = Mu =      45.47
+
+
+-----------------------------------------------
+Results of CollisionOver test:
+
+POISSON approximation                 :
+Expected number of collisions = N*Mu  :     1364.24
+Observed number of collisions         :     1318
+p-value of test                       :    0.89
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :  131940795334438
+  j =  1                              :        599997364
+  j =  2                              :             1318
+  j =  3                              :                0
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:05:21.30
+
+Generator state:
+
+
+
+
+***********************************************************
+Test smarsa_CollisionOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N = 30,  n = 20000000,  r =  0,   d = 16384,   t =  3,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =      4398046511104
+       Expected number per cell =  1 /  219902.33
+       EColl = n^2 / (2k) =  45.47473509
+       Hashing =   TRUE
+
+       Collision test
+
+       CollisionOver:   density = n / k =  1 /  219902.33
+       Expected number of collisions = Mu =      45.47
+
+
+-----------------------------------------------
+Results of CollisionOver test:
+
+POISSON approximation                 :
+Expected number of collisions = N*Mu  :     1364.24
+Observed number of collisions         :     1398
+p-value of test                       :    0.18
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :  131940795334518
+  j =  1                              :        599997204
+  j =  2                              :             1398
+  j =  3                              :                0
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:07:54.80
+
+Generator state:
+
+
+
+
+***********************************************************
+Test smarsa_CollisionOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N = 30,  n = 20000000,  r = 16,   d = 16384,   t =  3,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =      4398046511104
+       Expected number per cell =  1 /  219902.33
+       EColl = n^2 / (2k) =  45.47473509
+       Hashing =   TRUE
+
+       Collision test
+
+       CollisionOver:   density = n / k =  1 /  219902.33
+       Expected number of collisions = Mu =      45.47
+
+
+-----------------------------------------------
+Results of CollisionOver test:
+
+POISSON approximation                 :
+Expected number of collisions = N*Mu  :     1364.24
+Observed number of collisions         :     1362
+p-value of test                       :    0.52
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :  131940795334482
+  j =  1                              :        599997276
+  j =  2                              :             1362
+  j =  3                              :                0
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:08:02.90
+
+Generator state:
+
+
+
+
+***********************************************************
+Test smarsa_CollisionOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N = 30,  n = 20000000,  r =  0,   d =   64,   t =  7,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =      4398046511104
+       Expected number per cell =  1 /  219902.33
+       EColl = n^2 / (2k) =  45.47473509
+       Hashing =   TRUE
+
+       Collision test
+
+       CollisionOver:   density = n / k =  1 /  219902.33
+       Expected number of collisions = Mu =      45.47
+
+
+-----------------------------------------------
+Results of CollisionOver test:
+
+POISSON approximation                 :
+Expected number of collisions = N*Mu  :     1364.24
+Observed number of collisions         :     1364
+p-value of test                       :    0.50
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :  131940795334484
+  j =  1                              :        599997272
+  j =  2                              :             1364
+  j =  3                              :                0
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:08:04.78
+
+Generator state:
+
+
+
+
+***********************************************************
+Test smarsa_CollisionOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N = 30,  n = 20000000,  r = 24,   d =   64,   t =  7,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =      4398046511104
+       Expected number per cell =  1 /  219902.33
+       EColl = n^2 / (2k) =  45.47473509
+       Hashing =   TRUE
+
+       Collision test
+
+       CollisionOver:   density = n / k =  1 /  219902.33
+       Expected number of collisions = Mu =      45.47
+
+
+-----------------------------------------------
+Results of CollisionOver test:
+
+POISSON approximation                 :
+Expected number of collisions = N*Mu  :     1364.24
+Observed number of collisions         :     1421
+p-value of test                       :    0.06
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :  131940795334541
+  j =  1                              :        599997158
+  j =  2                              :             1421
+  j =  3                              :                0
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:08:05.63
+
+Generator state:
+
+
+
+
+***********************************************************
+Test smarsa_CollisionOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N = 30,  n = 20000000,  r =  0,   d =    8,   t = 14,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =      4398046511104
+       Expected number per cell =  1 /  219902.33
+       EColl = n^2 / (2k) =  45.47473509
+       Hashing =   TRUE
+
+       Collision test
+
+       CollisionOver:   density = n / k =  1 /  219902.33
+       Expected number of collisions = Mu =      45.47
+
+
+-----------------------------------------------
+Results of CollisionOver test:
+
+POISSON approximation                 :
+Expected number of collisions = N*Mu  :     1364.24
+Observed number of collisions         :     1344
+p-value of test                       :    0.70
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :  131940795334464
+  j =  1                              :        599997312
+  j =  2                              :             1344
+  j =  3                              :                0
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:08:04.46
+
+Generator state:
+
+
+
+
+***********************************************************
+Test smarsa_CollisionOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N = 30,  n = 20000000,  r = 27,   d =    8,   t = 14,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =      4398046511104
+       Expected number per cell =  1 /  219902.33
+       EColl = n^2 / (2k) =  45.47473509
+       Hashing =   TRUE
+
+       Collision test
+
+       CollisionOver:   density = n / k =  1 /  219902.33
+       Expected number of collisions = Mu =      45.47
+
+
+-----------------------------------------------
+Results of CollisionOver test:
+
+POISSON approximation                 :
+Expected number of collisions = N*Mu  :     1364.24
+Observed number of collisions         :     1347
+p-value of test                       :    0.67
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :  131940795334467
+  j =  1                              :        599997306
+  j =  2                              :             1347
+  j =  3                              :                0
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:08:06.30
+
+Generator state:
+
+
+
+
+***********************************************************
+Test smarsa_CollisionOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N = 30,  n = 20000000,  r =  0,   d =    4,   t = 21,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =      4398046511104
+       Expected number per cell =  1 /  219902.33
+       EColl = n^2 / (2k) =  45.47473509
+       Hashing =   TRUE
+
+       Collision test
+
+       CollisionOver:   density = n / k =  1 /  219902.33
+       Expected number of collisions = Mu =      45.47
+
+
+-----------------------------------------------
+Results of CollisionOver test:
+
+POISSON approximation                 :
+Expected number of collisions = N*Mu  :     1364.24
+Observed number of collisions         :     1438
+p-value of test                       :    0.02
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :  131940795334558
+  j =  1                              :        599997124
+  j =  2                              :             1438
+  j =  3                              :                0
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:08:00.97
+
+Generator state:
+
+
+
+
+***********************************************************
+Test smarsa_CollisionOver calling smultin_MultinomialOver
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smultin_MultinomialOver test:
+-----------------------------------------------
+   N = 30,  n = 20000000,  r = 28,   d =    4,   t = 21,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellSerial
+       Number of cells = d^t =      4398046511104
+       Expected number per cell =  1 /  219902.33
+       EColl = n^2 / (2k) =  45.47473509
+       Hashing =   TRUE
+
+       Collision test
+
+       CollisionOver:   density = n / k =  1 /  219902.33
+       Expected number of collisions = Mu =      45.47
+
+
+-----------------------------------------------
+Results of CollisionOver test:
+
+POISSON approximation                 :
+Expected number of collisions = N*Mu  :     1364.24
+Observed number of collisions         :     1318
+p-value of test                       :    0.89
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :  131940795334438
+  j =  1                              :        599997364
+  j =  2                              :             1318
+  j =  3                              :                0
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:08:28.22
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_BirthdaySpacings test:
+-----------------------------------------------
+   N = 100,  n = 10000000,  r =  0,    d = 2147483648,    t = 2,    p = 1
+
+
+      Number of cells = d^t = 4611686018427387904
+      Lambda = Poisson mean =      54.2101
+
+
+----------------------------------------------------
+Total expected number = N*Lambda      :    5421.01
+Total observed number                 :    5472
+p-value of test                       :    0.25
+
+
+-----------------------------------------------
+CPU time used                    :  00:07:13.11
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_BirthdaySpacings test:
+-----------------------------------------------
+   N = 20,  n = 20000000,  r =  0,    d = 2097152,    t = 3,    p = 1
+
+
+      Number of cells = d^t = 9223372036854775808
+      Lambda = Poisson mean =     216.8404
+
+
+----------------------------------------------------
+Total expected number = N*Lambda      :    4336.81
+Total observed number                 :    4357
+p-value of test                       :    0.38
+
+
+-----------------------------------------------
+CPU time used                    :  00:03:04.22
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_BirthdaySpacings test:
+-----------------------------------------------
+   N = 20,  n = 30000000,  r = 14,    d = 65536,    t = 4,    p = 1
+
+
+      Number of cells = d^t = 18446744073709551616
+      Lambda = Poisson mean =     365.9182
+
+
+----------------------------------------------------
+Total expected number = N*Lambda      :    7318.36
+Total observed number                 :    7261
+p-value of test                       :    0.75
+
+
+-----------------------------------------------
+CPU time used                    :  00:05:47.68
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_BirthdaySpacings test:
+-----------------------------------------------
+   N = 20,  n = 20000000,  r =  0,    d = 512,    t = 7,    p = 1
+
+
+      Number of cells = d^t = 9223372036854775808
+      Lambda = Poisson mean =     216.8404
+
+
+----------------------------------------------------
+Total expected number = N*Lambda      :    4336.81
+Total observed number                 :    4406
+p-value of test                       :    0.15
+
+
+-----------------------------------------------
+CPU time used                    :  00:05:00.94
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_BirthdaySpacings test:
+-----------------------------------------------
+   N = 20,  n = 20000000,  r =  7,    d = 512,    t = 7,    p = 1
+
+
+      Number of cells = d^t = 9223372036854775808
+      Lambda = Poisson mean =     216.8404
+
+
+----------------------------------------------------
+Total expected number = N*Lambda      :    4336.81
+Total observed number                 :    4300
+p-value of test                       :    0.71
+
+
+-----------------------------------------------
+CPU time used                    :  00:05:01.63
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_BirthdaySpacings test:
+-----------------------------------------------
+   N = 20,  n = 30000000,  r = 14,    d = 256,    t = 8,    p = 1
+
+
+      Number of cells = d^t = 18446744073709551616
+      Lambda = Poisson mean =     365.9182
+
+
+----------------------------------------------------
+Total expected number = N*Lambda      :    7318.36
+Total observed number                 :    7501
+p-value of test                       :    0.02
+
+
+-----------------------------------------------
+CPU time used                    :  00:08:18.63
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_BirthdaySpacings test:
+-----------------------------------------------
+   N = 20,  n = 30000000,  r = 22,    d = 256,    t = 8,    p = 1
+
+
+      Number of cells = d^t = 18446744073709551616
+      Lambda = Poisson mean =     365.9182
+
+
+----------------------------------------------------
+Total expected number = N*Lambda      :    7318.36
+Total observed number                 :    7446
+p-value of test                       :    0.07
+
+
+-----------------------------------------------
+CPU time used                    :  00:08:17.61
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_BirthdaySpacings test:
+-----------------------------------------------
+   N = 20,  n = 30000000,  r =  0,    d = 16,    t = 16,    p = 1
+
+
+      Number of cells = d^t = 18446744073709551616
+      Lambda = Poisson mean =     365.9182
+
+
+----------------------------------------------------
+Total expected number = N*Lambda      :    7318.36
+Total observed number                 :    7240
+p-value of test                       :    0.82
+
+
+-----------------------------------------------
+CPU time used                    :  00:13:09.04
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_BirthdaySpacings test:
+-----------------------------------------------
+   N = 20,  n = 30000000,  r = 26,    d = 16,    t = 16,    p = 1
+
+
+      Number of cells = d^t = 18446744073709551616
+      Lambda = Poisson mean =     365.9182
+
+
+----------------------------------------------------
+Total expected number = N*Lambda      :    7318.36
+Total observed number                 :    7496
+p-value of test                       :    0.02
+
+
+-----------------------------------------------
+CPU time used                    :  00:13:36.37
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+snpair_ClosePairs test:
+-----------------------------------------------
+   N = 30,  n = 6000000,  r =  0,  t = 3,  p = 0,  m = 30,  Torus =  TRUE
+
+
+---------------------------------------
+Test based on the 2 nearest points (NP):
+
+Stat. AD on the N values (NP)         :    0.88
+p-value of test                       :    0.43
+
+
+A2 test based on the spacings between the
+   successive jump times of process Y_n(t):
+
+A2 test on the values of A2 (m-NP)    :    1.42
+p-value of test                       :    0.20
+
+Test on the Nm values of W_{n,i}(mNP1):    0.30
+p-value of test                       :    0.94
+
+Test on the jump times of Y
+   (superposition of Yn):
+
+Expected number of jumps of Y = mN    :     900
+Number of jumps of Y                  :     924
+p-value of test                       :    0.22
+
+Stat. AD (mNP2)                       :    4.37
+p-value of test                       :  5.8e-3
+
+Stat. AD after spacings (mNP2-S)      :    2.46
+p-value of test                       :    0.05
+
+-----------------------------------------------
+CPU time used                    :  00:03:31.81
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+snpair_ClosePairs test:
+-----------------------------------------------
+   N = 20,  n = 4000000,  r =  0,  t = 5,  p = 0,  m = 30,  Torus =  TRUE
+
+
+---------------------------------------
+Test based on the 2 nearest points (NP):
+
+Stat. AD on the N values (NP)         :    1.15
+p-value of test                       :    0.29
+
+
+A2 test based on the spacings between the
+   successive jump times of process Y_n(t):
+
+A2 test on the values of A2 (m-NP)    :    0.63
+p-value of test                       :    0.62
+
+Test on the Nm values of W_{n,i}(mNP1):    0.57
+p-value of test                       :    0.68
+
+Test on the jump times of Y
+   (superposition of Yn):
+
+Expected number of jumps of Y = mN    :     600
+Number of jumps of Y                  :     629
+p-value of test                       :    0.12
+
+Stat. AD (mNP2)                       :    0.83
+p-value of test                       :    0.46
+
+Stat. AD after spacings (mNP2-S)      :    1.13
+p-value of test                       :    0.29
+
+-----------------------------------------------
+CPU time used                    :  00:02:34.97
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+snpair_ClosePairs test:
+-----------------------------------------------
+   N = 10,  n = 3000000,  r =  0,  t = 9,  p = 0,  m = 30,  Torus =  TRUE
+
+
+---------------------------------------
+Test based on the 2 nearest points (NP):
+
+Stat. AD on the N values (NP)         :    0.20
+p-value of test                       :    0.99
+
+
+A2 test based on the spacings between the
+   successive jump times of process Y_n(t):
+
+A2 test on the values of A2 (m-NP)    :    1.91
+p-value of test                       :    0.10
+
+Test on the Nm values of W_{n,i}(mNP1):    2.28
+p-value of test                       :    0.06
+
+Test on the jump times of Y
+   (superposition of Yn):
+
+Expected number of jumps of Y = mN    :     300
+Number of jumps of Y                  :     267
+p-value of test                       :    0.97
+
+Stat. AD (mNP2)                       :    0.45
+p-value of test                       :    0.80
+
+Stat. AD after spacings (mNP2-S)      :    1.09
+p-value of test                       :    0.31
+
+-----------------------------------------------
+CPU time used                    :  00:04:04.70
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+snpair_ClosePairs test:
+-----------------------------------------------
+   N =  5,  n = 2000000,  r =  0,  t = 16,  p = 0,  m = 30,  Torus =  TRUE
+
+
+---------------------------------------
+Test based on the 2 nearest points (NP):
+
+Stat. AD on the N values (NP)         :    2.14
+p-value of test                       :    0.08
+
+
+A2 test based on the spacings between the
+   successive jump times of process Y_n(t):
+
+A2 test on the values of A2 (m-NP)    :    0.46
+p-value of test                       :    0.78
+
+Test on the Nm values of W_{n,i}(mNP1):    1.81
+p-value of test                       :    0.12
+
+Test on the jump times of Y
+   (superposition of Yn):
+
+Expected number of jumps of Y = mN    :     150
+Number of jumps of Y                  :     133
+p-value of test                       :    0.91
+
+Stat. AD (mNP2)                       :    0.28
+p-value of test                       :    0.95
+
+Stat. AD after spacings (mNP2-S)      :    0.89
+p-value of test                       :    0.42
+
+-----------------------------------------------
+CPU time used                    :  00:04:33.18
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_SimpPoker test:
+-----------------------------------------------
+   N =  1,  n = 400000000,  r =  0,   d =    8,   k =    8
+
+
+-----------------------------------------------
+Number of degrees of freedom          :    7
+Chi-square statistic                  :    3.71
+p-value of test                       :    0.81
+
+-----------------------------------------------
+CPU time used                    :  00:03:54.51
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_SimpPoker test:
+-----------------------------------------------
+   N =  1,  n = 400000000,  r = 27,   d =    8,   k =    8
+
+
+-----------------------------------------------
+Number of degrees of freedom          :    7
+Chi-square statistic                  :    7.44
+p-value of test                       :    0.38
+
+-----------------------------------------------
+CPU time used                    :  00:04:14.87
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_SimpPoker test:
+-----------------------------------------------
+   N =  1,  n = 100000000,  r =  0,   d =   32,   k =   32
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   18
+Chi-square statistic                  :   32.67
+p-value of test                       :    0.02
+
+-----------------------------------------------
+CPU time used                    :  00:03:52.77
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_SimpPoker test:
+-----------------------------------------------
+   N =  1,  n = 100000000,  r = 25,   d =   32,   k =   32
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   18
+Chi-square statistic                  :   15.82
+p-value of test                       :    0.60
+
+-----------------------------------------------
+CPU time used                    :  00:04:11.09
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_CouponCollector test:
+-----------------------------------------------
+   N =  1,  n = 200000000,  r =  0,   d =    8
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   54
+Chi-square statistic                  :   62.92
+p-value of test                       :    0.19
+
+-----------------------------------------------
+CPU time used                    :  00:04:58.36
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_CouponCollector test:
+-----------------------------------------------
+   N =  1,  n = 200000000,  r = 10,   d =    8
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   54
+Chi-square statistic                  :   68.03
+p-value of test                       :    0.09
+
+-----------------------------------------------
+CPU time used                    :  00:05:25.44
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_CouponCollector test:
+-----------------------------------------------
+   N =  1,  n = 200000000,  r = 20,   d =    8
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   54
+Chi-square statistic                  :   61.92
+p-value of test                       :    0.21
+
+-----------------------------------------------
+CPU time used                    :  00:05:19.63
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_CouponCollector test:
+-----------------------------------------------
+   N =  1,  n = 200000000,  r = 27,   d =    8
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   54
+Chi-square statistic                  :   73.57
+p-value of test                       :    0.04
+
+-----------------------------------------------
+CPU time used                    :  00:05:18.62
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_Gap test:
+-----------------------------------------------
+   N =  1,  n = 500000000,  r =  0,   Alpha =        0,   Beta  =   0.0625
+
+
+-----------------------------------------------
+Number of degrees of freedom          :  232
+Chi-square statistic                  :  251.30
+p-value of test                       :    0.18
+
+-----------------------------------------------
+CPU time used                    :  00:08:06.80
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_Gap test:
+-----------------------------------------------
+   N =  1,  n = 300000000,  r = 25,   Alpha =        0,   Beta  =  0.03125
+
+
+-----------------------------------------------
+Number of degrees of freedom          :  434
+Chi-square statistic                  :  433.04
+p-value of test                       :    0.50
+
+-----------------------------------------------
+CPU time used                    :  00:10:07.84
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_Gap test:
+-----------------------------------------------
+   N =  1,  n = 100000000,  r =  0,   Alpha =        0,   Beta  = 0.0078125
+
+
+-----------------------------------------------
+Number of degrees of freedom          : 1437
+Chi-square statistic                  : 1442.22
+p-value of test                       :    0.46
+
+-----------------------------------------------
+CPU time used                    :  00:12:17.44
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_Gap test:
+-----------------------------------------------
+   N =  1,  n = 10000000,  r = 20,   Alpha =        0,   Beta  = 0.000976562
+
+
+-----------------------------------------------
+Number of degrees of freedom          : 7046
+Chi-square statistic                  : 7144.68
+p-value of test                       :    0.20
+
+-----------------------------------------------
+CPU time used                    :  00:10:31.20
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_Run test:
+-----------------------------------------------
+   N =  5,  n = 1000000000,  r =  0,   Up = FALSE
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :   0.020
+p-value of test                       :    0.98
+
+Kolmogorov-Smirnov- statistic = D-    :    0.64
+p-value of test                       :  7.6e-3
+
+Anderson-Darling statistic = A2       :    5.02
+p-value of test                       :  3.1e-3
+
+Test on the sum of all N observations
+Number of degrees of freedom          :   30
+Chi-square statistic                  :   55.91
+p-value of test                       :  2.8e-3
+
+-----------------------------------------------
+CPU time used                    :  00:05:33.44
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_Run test:
+-----------------------------------------------
+   N = 10,  n = 1000000000,  r = 15,   Up =  TRUE
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.13
+p-value of test                       :    0.66
+
+Kolmogorov-Smirnov- statistic = D-    :    0.23
+p-value of test                       :    0.30
+
+Anderson-Darling statistic = A2       :    0.58
+p-value of test                       :    0.66
+
+Test on the sum of all N observations
+Number of degrees of freedom          :   60
+Chi-square statistic                  :   66.53
+p-value of test                       :    0.26
+
+-----------------------------------------------
+CPU time used                    :  00:11:22.51
+
+Generator state:
+
+
+
+
+***********************************************************
+Test sknuth_Permutation calling smultin_Multinomial
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smultin_Multinomial test:
+-----------------------------------------------
+   N =  1,  n = 1000000000,  r =  5,   t =  3,
+       Sparse =  FALSE
+
+       GenerCell = smultin_GenerCellPermut
+       Number of cells = t! =                  6
+       Expected number per cell =  1.6666667e+08
+       Hashing =  FALSE
+
+   For Delta > -1, we use the ChiSquare approximation
+   Correction factor of the ChiSquare: 
+       Delta =     1,    Mu =  2.5000002e-09,    Sigma =          1
+
+-----------------------------------------------
+Test Results for Delta =   1.0000
+
+Number of degrees of freedom          :    5
+Value of the statistic                :    7.25
+p-value of test                       :    0.20
+
+
+-----------------------------------------------
+CPU time used                    :  00:03:28.06
+
+Generator state:
+
+
+
+
+***********************************************************
+Test sknuth_Permutation calling smultin_Multinomial
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smultin_Multinomial test:
+-----------------------------------------------
+   N =  1,  n = 1000000000,  r =  5,   t =  5,
+       Sparse =  FALSE
+
+       GenerCell = smultin_GenerCellPermut
+       Number of cells = t! =                120
+       Expected number per cell =   8333333.3
+       Hashing =  FALSE
+
+   For Delta > -1, we use the ChiSquare approximation
+   Correction factor of the ChiSquare: 
+       Delta =     1,    Mu =  5.9500005e-08,    Sigma =          1
+
+-----------------------------------------------
+Test Results for Delta =   1.0000
+
+Number of degrees of freedom          :  119
+Value of the statistic                :  118.67
+p-value of test                       :    0.49
+
+
+-----------------------------------------------
+CPU time used                    :  00:06:13.88
+
+Generator state:
+
+
+
+
+***********************************************************
+Test sknuth_Permutation calling smultin_Multinomial
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smultin_Multinomial test:
+-----------------------------------------------
+   N =  1,  n = 500000000,  r =  5,   t =  7,
+       Sparse =  FALSE
+
+       GenerCell = smultin_GenerCellPermut
+       Number of cells = t! =               5040
+       Expected number per cell =   99206.349
+       Hashing =  FALSE
+
+   For Delta > -1, we use the ChiSquare approximation
+   Correction factor of the ChiSquare: 
+       Delta =     1,    Mu =  5.0390004e-06,    Sigma =          1
+
+-----------------------------------------------
+Test Results for Delta =   1.0000
+
+Number of degrees of freedom          : 5039
+Value of the statistic                : 5016.96
+p-value of test                       :    0.58
+
+
+-----------------------------------------------
+CPU time used                    :  00:04:38.72
+
+Generator state:
+
+
+
+
+***********************************************************
+Test sknuth_Permutation calling smultin_Multinomial
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smultin_Multinomial test:
+-----------------------------------------------
+   N =  1,  n = 500000000,  r = 10,   t = 10,
+       Sparse =  FALSE
+
+       GenerCell = smultin_GenerCellPermut
+       Number of cells = t! =            3628800
+       Expected number per cell =    137.7866
+       Hashing =  FALSE
+
+   For Delta > -1, we use the ChiSquare approximation
+   Correction factor of the ChiSquare: 
+       Delta =     1,    Mu =   0.0036287993,    Sigma =          1
+
+-----------------------------------------------
+Test Results for Delta =   1.0000
+
+Number of degrees of freedom          : 3628799
+Value of the statistic                : 3.63e+6
+p-value of test                       :    0.25
+
+
+-----------------------------------------------
+CPU time used                    :  00:08:45.54
+
+Generator state:
+
+
+
+
+***********************************************************
+Test sknuth_CollisionPermut calling smultin_Multinomial
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smultin_Multinomial test:
+-----------------------------------------------
+   N = 20,  n = 20000000,  r =  0,   t = 14,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellPermut
+       Number of cells = t! =        87178291200
+       Expected number per cell =  1 /  4358.9146
+       EColl = n^2 / (2k) =   2294.14912
+       Hashing =   TRUE
+
+       Collision test,    Mu =      2293.9736,    Sigma =    47.8841
+
+-----------------------------------------------
+Test Results for Collisions
+
+For the total number of collisions, we use
+      the Poisson approximation:
+Expected number of collisions = N*Mu  :    45879.47
+Observed number of collisions         :    45917
+p-value of test                       :    0.43
+
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :    1743165869917
+  j =  1                              :        399908167
+  j =  2                              :            45915
+  j =  3                              :                1
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:11:15.49
+
+Generator state:
+
+
+
+
+***********************************************************
+Test sknuth_CollisionPermut calling smultin_Multinomial
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smultin_Multinomial test:
+-----------------------------------------------
+   N = 20,  n = 20000000,  r = 10,   t = 14,
+       Sparse =   TRUE
+
+       GenerCell = smultin_GenerCellPermut
+       Number of cells = t! =        87178291200
+       Expected number per cell =  1 /  4358.9146
+       EColl = n^2 / (2k) =   2294.14912
+       Hashing =   TRUE
+
+       Collision test,    Mu =      2293.9736,    Sigma =    47.8841
+
+-----------------------------------------------
+Test Results for Collisions
+
+For the total number of collisions, we use
+      the Poisson approximation:
+Expected number of collisions = N*Mu  :    45879.47
+Observed number of collisions         :    45925
+p-value of test                       :    0.42
+
+
+-----------------------------
+Total number of cells containing j balls
+
+  j =  0                              :    1743165869925
+  j =  1                              :        399908154
+  j =  2                              :            45917
+  j =  3                              :                4
+  j =  4                              :                0
+  j =  5                              :                0
+
+-----------------------------------------------
+CPU time used                    :  00:11:36.24
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_MaxOft test:
+-----------------------------------------------
+   N = 40,  n = 10000000,  r =  0,   d = 100000,   t =  8
+
+      Number of categories = 100000
+      Expected number per category  = 100.00
+
+
+-----------------------------------------------
+Test results for chi2 with 99999 degrees of freedom:
+
+Kolmogorov-Smirnov+ statistic = D+    :   0.061
+p-value of test                       :    0.72
+
+Kolmogorov-Smirnov- statistic = D-    :   0.100
+p-value of test                       :    0.42
+
+Anderson-Darling statistic = A2       :    0.65
+p-value of test                       :    0.60
+
+Test on the sum of all N observations
+Number of degrees of freedom          : 3999960
+Chi-square statistic                  : 4.00e+6
+p-value of test                       :    0.17
+
+
+-----------------------------------------------
+Test results for Anderson-Darling:
+
+Kolmogorov-Smirnov+ statistic = D+    :   0.094
+p-value of test                       :    0.46
+
+Kolmogorov-Smirnov- statistic = D-    :   0.048
+p-value of test                       :    0.81
+
+Anderson-Darling statistic = A2       :    0.26
+p-value of test                       :    0.97
+
+
+-----------------------------------------------
+CPU time used                    :  00:06:38.50
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_MaxOft test:
+-----------------------------------------------
+   N = 30,  n = 10000000,  r =  0,   d = 100000,   t = 16
+
+      Number of categories = 100000
+      Expected number per category  = 100.00
+
+
+-----------------------------------------------
+Test results for chi2 with 99999 degrees of freedom:
+
+Kolmogorov-Smirnov+ statistic = D+    :   0.054
+p-value of test                       :    0.81
+
+Kolmogorov-Smirnov- statistic = D-    :    0.10
+p-value of test                       :    0.51
+
+Anderson-Darling statistic = A2       :    0.33
+p-value of test                       :    0.92
+
+Test on the sum of all N observations
+Number of degrees of freedom          : 2999970
+Chi-square statistic                  : 3.00e+6
+p-value of test                       :    0.31
+
+
+-----------------------------------------------
+Test results for Anderson-Darling:
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.12
+p-value of test                       :    0.42
+
+Kolmogorov-Smirnov- statistic = D-    :   0.062
+p-value of test                       :    0.76
+
+Anderson-Darling statistic = A2       :    0.73
+p-value of test                       :    0.54
+
+
+-----------------------------------------------
+CPU time used                    :  00:07:10.06
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_MaxOft test:
+-----------------------------------------------
+   N = 20,  n = 10000000,  r =  0,   d = 100000,   t = 24
+
+      Number of categories = 100000
+      Expected number per category  = 100.00
+
+
+-----------------------------------------------
+Test results for chi2 with 99999 degrees of freedom:
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.24
+p-value of test                       :    0.08
+
+Kolmogorov-Smirnov- statistic = D-    :   0.046
+p-value of test                       :    0.89
+
+Anderson-Darling statistic = A2       :    1.04
+p-value of test                       :    0.34
+
+Test on the sum of all N observations
+Number of degrees of freedom          : 1999980
+Chi-square statistic                  : 2.00e+6
+p-value of test                       :    0.88
+
+
+-----------------------------------------------
+Test results for Anderson-Darling:
+
+Kolmogorov-Smirnov+ statistic = D+    :   0.098
+p-value of test                       :    0.64
+
+Kolmogorov-Smirnov- statistic = D-    :    0.12
+p-value of test                       :    0.53
+
+Anderson-Darling statistic = A2       :    0.40
+p-value of test                       :    0.85
+
+
+-----------------------------------------------
+CPU time used                    :  00:06:18.93
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sknuth_MaxOft test:
+-----------------------------------------------
+   N = 20,  n = 10000000,  r =  0,   d = 100000,   t = 32
+
+      Number of categories = 100000
+      Expected number per category  = 100.00
+
+
+-----------------------------------------------
+Test results for chi2 with 99999 degrees of freedom:
+
+Kolmogorov-Smirnov+ statistic = D+    :   0.067
+p-value of test                       :    0.80
+
+Kolmogorov-Smirnov- statistic = D-    :    0.13
+p-value of test                       :    0.45
+
+Anderson-Darling statistic = A2       :    0.36
+p-value of test                       :    0.89
+
+Test on the sum of all N observations
+Number of degrees of freedom          : 1999980
+Chi-square statistic                  : 2.00e+6
+p-value of test                       :    0.34
+
+
+-----------------------------------------------
+Test results for Anderson-Darling:
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.15
+p-value of test                       :    0.38
+
+Kolmogorov-Smirnov- statistic = D-    :   0.094
+p-value of test                       :    0.66
+
+Anderson-Darling statistic = A2       :    0.44
+p-value of test                       :    0.81
+
+
+-----------------------------------------------
+CPU time used                    :  00:07:48.16
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+svaria_SampleProd test:
+-----------------------------------------------
+   N = 40,  n = 10000000,  r =  0,   t = 8
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :   0.048
+p-value of test                       :    0.81
+
+Kolmogorov-Smirnov- statistic = D-    :    0.13
+p-value of test                       :    0.26
+
+Anderson-Darling statistic = A2       :    1.00
+p-value of test                       :    0.36
+
+-----------------------------------------------
+CPU time used                    :  00:04:52.38
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+svaria_SampleProd test:
+-----------------------------------------------
+   N = 20,  n = 10000000,  r =  0,   t = 16
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :   0.069
+p-value of test                       :    0.79
+
+Kolmogorov-Smirnov- statistic = D-    :    0.12
+p-value of test                       :    0.50
+
+Anderson-Darling statistic = A2       :    0.34
+p-value of test                       :    0.91
+
+-----------------------------------------------
+CPU time used                    :  00:03:58.11
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+svaria_SampleProd test:
+-----------------------------------------------
+   N = 20,  n = 10000000,  r =  0,   t = 24
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.24
+p-value of test                       :    0.09
+
+Kolmogorov-Smirnov- statistic = D-    :   0.040
+p-value of test                       :    0.91
+
+Anderson-Darling statistic = A2       :    1.07
+p-value of test                       :    0.32
+
+-----------------------------------------------
+CPU time used                    :  00:05:27.66
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+svaria_SampleMean test:
+-----------------------------------------------
+   N = 20000000,  n = 30,  r =  0
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    : 1.86e-4
+p-value of test                       :    0.25
+
+Kolmogorov-Smirnov- statistic = D-    : 2.90e-5
+p-value of test                       :    0.97
+
+Anderson-Darling statistic = A2       :    1.13
+p-value of test                       :    0.30
+
+-----------------------------------------------
+CPU time used                    :  00:01:02.38
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+svaria_SampleMean test:
+-----------------------------------------------
+   N = 20000000,  n = 30,  r = 10
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    : 7.87e-5
+p-value of test                       :    0.78
+
+Kolmogorov-Smirnov- statistic = D-    : 1.53e-4
+p-value of test                       :    0.39
+
+Anderson-Darling statistic = A2       :    0.53
+p-value of test                       :    0.72
+
+-----------------------------------------------
+CPU time used                    :  00:01:03.65
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+svaria_SampleCorr test:
+-----------------------------------------------
+   N =  1,  n = 2000000000,  r =  0,   k = 1
+
+
+-----------------------------------------------
+Normal statistic                      :   -0.21
+p-value of test                       :    0.58
+
+-----------------------------------------------
+CPU time used                    :  00:02:04.27
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+svaria_SampleCorr test:
+-----------------------------------------------
+   N =  1,  n = 2000000000,  r =  0,   k = 2
+
+
+-----------------------------------------------
+Normal statistic                      :   -1.10
+p-value of test                       :    0.87
+
+-----------------------------------------------
+CPU time used                    :  00:02:04.50
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+svaria_AppearanceSpacings test:
+-----------------------------------------------
+   N =  1,   Q = 10000000,   K = 1000000000,   r = 0,   s = 3,   L = 15
+
+   Sequences of n = (K + Q)L =  15150000000 bits
+   Q = 10000000 initialization blocks
+   K = 1000000000 blocks for the test
+   the blocks have L = 15 bits
+
+
+
+-----------------------------------------------
+Normal statistic                      :    1.36
+p-value of test                       :    0.09
+
+-----------------------------------------------
+CPU time used                    :  00:06:41.47
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+svaria_AppearanceSpacings test:
+-----------------------------------------------
+   N =  1,   Q = 10000000,   K = 1000000000,   r = 27,   s = 3,   L = 15
+
+   Sequences of n = (K + Q)L =  15150000000 bits
+   Q = 10000000 initialization blocks
+   K = 1000000000 blocks for the test
+   the blocks have L = 15 bits
+
+
+
+-----------------------------------------------
+Normal statistic                      :    0.45
+p-value of test                       :    0.33
+
+-----------------------------------------------
+CPU time used                    :  00:06:54.84
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+svaria_WeightDistrib test:
+-----------------------------------------------
+   N =  1,  n = 20000000,  r =  0,  k = 256,  Alpha =      0,  Beta =   0.25
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   67
+Chi-square statistic                  :   62.35
+p-value of test                       :    0.64
+
+-----------------------------------------------
+CPU time used                    :  00:04:45.50
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+svaria_WeightDistrib test:
+-----------------------------------------------
+   N =  1,  n = 20000000,  r = 20,  k = 256,  Alpha =      0,  Beta =   0.25
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   67
+Chi-square statistic                  :   83.13
+p-value of test                       :    0.09
+
+-----------------------------------------------
+CPU time used                    :  00:04:59.49
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+svaria_WeightDistrib test:
+-----------------------------------------------
+   N =  1,  n = 20000000,  r = 28,  k = 256,  Alpha =      0,  Beta =   0.25
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   67
+Chi-square statistic                  :   94.36
+p-value of test                       :    0.02
+
+-----------------------------------------------
+CPU time used                    :  00:05:00.06
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+svaria_WeightDistrib test:
+-----------------------------------------------
+   N =  1,  n = 20000000,  r =  0,  k = 256,  Alpha =      0,  Beta = 0.0625
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   37
+Chi-square statistic                  :   41.05
+p-value of test                       :    0.30
+
+-----------------------------------------------
+CPU time used                    :  00:04:45.65
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+svaria_WeightDistrib test:
+-----------------------------------------------
+   N =  1,  n = 20000000,  r = 10,  k = 256,  Alpha =      0,  Beta = 0.0625
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   37
+Chi-square statistic                  :   45.51
+p-value of test                       :    0.16
+
+-----------------------------------------------
+CPU time used                    :  00:05:00.11
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+svaria_WeightDistrib test:
+-----------------------------------------------
+   N =  1,  n = 20000000,  r = 26,  k = 256,  Alpha =      0,  Beta = 0.0625
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   37
+Chi-square statistic                  :   35.13
+p-value of test                       :    0.56
+
+-----------------------------------------------
+CPU time used                    :  00:04:58.63
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+svaria_SumCollector test:
+-----------------------------------------------
+   N =  1,  n = 500000000,  r =  0,   g = 10
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   29
+Chi-square statistic                  :   33.11
+p-value of test                       :    0.27
+
+-----------------------------------------------
+CPU time used                    :  00:09:57.88
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_MatrixRank test:
+-----------------------------------------------
+   N = 10,  n = 1000000,  r =  0,    s = 5,    L = 30,    k = 30
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.29
+p-value of test                       :    0.15
+
+Kolmogorov-Smirnov- statistic = D-    :   0.063
+p-value of test                       :    0.89
+
+Anderson-Darling statistic = A2       :    0.81
+p-value of test                       :    0.47
+
+Test on the sum of all N observations
+Number of degrees of freedom          :   40
+Chi-square statistic                  :   30.04
+p-value of test                       :    0.87
+
+-----------------------------------------------
+CPU time used                    :  00:03:34.90
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_MatrixRank test:
+-----------------------------------------------
+   N = 10,  n = 1000000,  r = 25,    s = 5,    L = 30,    k = 30
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.23
+p-value of test                       :    0.29
+
+Kolmogorov-Smirnov- statistic = D-    :    0.20
+p-value of test                       :    0.40
+
+Anderson-Darling statistic = A2       :    0.62
+p-value of test                       :    0.62
+
+Test on the sum of all N observations
+Number of degrees of freedom          :   40
+Chi-square statistic                  :   36.44
+p-value of test                       :    0.63
+
+-----------------------------------------------
+CPU time used                    :  00:03:34.20
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_MatrixRank test:
+-----------------------------------------------
+   N =  1,  n = 5000,  r =  0,    s = 4,    L = 1000,    k = 1000
+
+
+-----------------------------------------------
+Number of degrees of freedom          :    3
+Chi-square statistic                  :    6.31
+p-value of test                       :    0.10
+
+-----------------------------------------------
+CPU time used                    :  00:04:53.00
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_MatrixRank test:
+-----------------------------------------------
+   N =  1,  n = 5000,  r = 26,    s = 4,    L = 1000,    k = 1000
+
+
+-----------------------------------------------
+Number of degrees of freedom          :    3
+Chi-square statistic                  :    1.33
+p-value of test                       :    0.72
+
+-----------------------------------------------
+CPU time used                    :  00:04:54.91
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_MatrixRank test:
+-----------------------------------------------
+   N =  1,  n = 80,  r = 15,    s = 15,    L = 5000,    k = 5000
+
+
+-----------------------------------------------
+Number of degrees of freedom          :    2
+Chi-square statistic                  :    5.26
+p-value of test                       :    0.07
+
+-----------------------------------------------
+CPU time used                    :  00:03:32.61
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_MatrixRank test:
+-----------------------------------------------
+   N =  1,  n = 80,  r =  0,    s = 30,    L = 5000,    k = 5000
+
+
+-----------------------------------------------
+Number of degrees of freedom          :    2
+Chi-square statistic                  :    4.36
+p-value of test                       :    0.11
+
+-----------------------------------------------
+CPU time used                    :  00:03:02.45
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_Savir2 test:
+-----------------------------------------------
+   N = 10,  n = 10000000,  r = 10,    m = 1048576,    t = 30
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.12
+p-value of test                       :    0.70
+
+Kolmogorov-Smirnov- statistic = D-    :    0.14
+p-value of test                       :    0.64
+
+Anderson-Darling statistic = A2       :    0.25
+p-value of test                       :    0.97
+
+Test on the sum of all N observations
+Number of degrees of freedom          :  130
+Chi-square statistic                  :  131.55
+p-value of test                       :    0.45
+
+-----------------------------------------------
+CPU time used                    :  00:02:48.09
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+smarsa_GCD test:
+-----------------------------------------------
+   N = 10,  n = 50000000,  r =  0,   s = 30
+
+
+-----------------------------------------------
+Test results for GCD values:
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.11
+p-value of test                       :    0.72
+
+Kolmogorov-Smirnov- statistic = D-    :    0.23
+p-value of test                       :    0.31
+
+Anderson-Darling statistic = A2       :    1.04
+p-value of test                       :    0.33
+
+Test on the sum of all N observations
+Number of degrees of freedom          : 17430
+Chi-square statistic                  :17619.40
+p-value of test                       :    0.16
+
+
+
+-----------------------------------------------
+CPU time used                    :  00:03:12.74
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+swalk_RandomWalk1 test:
+-----------------------------------------------
+   N =  1,  n = 100000000,  r =  0,   s = 5,   L0 =   50,   L1 =   50
+
+
+
+-----------------------------------------------
+Test on the values of the Statistic H
+
+Number of degrees of freedom          :   36
+ChiSquare statistic                   :   23.65
+p-value of test                       :    0.94
+
+
+-----------------------------------------------
+Test on the values of the Statistic M
+
+Number of degrees of freedom          :   35
+ChiSquare statistic                   :   24.60
+p-value of test                       :    0.91
+
+
+-----------------------------------------------
+Test on the values of the Statistic J
+
+Number of degrees of freedom          :   25
+ChiSquare statistic                   :   26.00
+p-value of test                       :    0.41
+
+
+-----------------------------------------------
+Test on the values of the Statistic R
+
+Number of degrees of freedom          :   24
+ChiSquare statistic                   :   14.41
+p-value of test                       :    0.94
+
+
+-----------------------------------------------
+Test on the values of the Statistic C
+
+Number of degrees of freedom          :   17
+ChiSquare statistic                   :   21.06
+p-value of test                       :    0.22
+
+
+-----------------------------------------------
+CPU time used                    :  00:01:56.50
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+swalk_RandomWalk1 test:
+-----------------------------------------------
+   N =  1,  n = 100000000,  r = 25,   s = 5,   L0 =   50,   L1 =   50
+
+
+
+-----------------------------------------------
+Test on the values of the Statistic H
+
+Number of degrees of freedom          :   36
+ChiSquare statistic                   :   45.86
+p-value of test                       :    0.13
+
+
+-----------------------------------------------
+Test on the values of the Statistic M
+
+Number of degrees of freedom          :   35
+ChiSquare statistic                   :   35.61
+p-value of test                       :    0.44
+
+
+-----------------------------------------------
+Test on the values of the Statistic J
+
+Number of degrees of freedom          :   25
+ChiSquare statistic                   :   12.75
+p-value of test                       :    0.98
+
+
+-----------------------------------------------
+Test on the values of the Statistic R
+
+Number of degrees of freedom          :   24
+ChiSquare statistic                   :   16.46
+p-value of test                       :    0.87
+
+
+-----------------------------------------------
+Test on the values of the Statistic C
+
+Number of degrees of freedom          :   17
+ChiSquare statistic                   :   15.14
+p-value of test                       :    0.59
+
+
+-----------------------------------------------
+CPU time used                    :  00:02:01.90
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+swalk_RandomWalk1 test:
+-----------------------------------------------
+   N =  1,  n = 10000000,  r =  0,   s = 10,   L0 = 1000,   L1 = 1000
+
+
+
+-----------------------------------------------
+Test on the values of the Statistic H
+
+Number of degrees of freedom          :  146
+ChiSquare statistic                   :  158.65
+p-value of test                       :    0.22
+
+
+-----------------------------------------------
+Test on the values of the Statistic M
+
+Number of degrees of freedom          :  146
+ChiSquare statistic                   :  156.13
+p-value of test                       :    0.27
+
+
+-----------------------------------------------
+Test on the values of the Statistic J
+
+Number of degrees of freedom          :  500
+ChiSquare statistic                   :  489.89
+p-value of test                       :    0.62
+
+
+-----------------------------------------------
+Test on the values of the Statistic R
+
+Number of degrees of freedom          :  136
+ChiSquare statistic                   :  128.61
+p-value of test                       :    0.66
+
+
+-----------------------------------------------
+Test on the values of the Statistic C
+
+Number of degrees of freedom          :   74
+ChiSquare statistic                   :   61.99
+p-value of test                       :    0.84
+
+
+-----------------------------------------------
+CPU time used                    :  00:02:17.83
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+swalk_RandomWalk1 test:
+-----------------------------------------------
+   N =  1,  n = 10000000,  r = 20,   s = 10,   L0 = 1000,   L1 = 1000
+
+
+
+-----------------------------------------------
+Test on the values of the Statistic H
+
+Number of degrees of freedom          :  146
+ChiSquare statistic                   :  115.07
+p-value of test                       :    0.97
+
+
+-----------------------------------------------
+Test on the values of the Statistic M
+
+Number of degrees of freedom          :  146
+ChiSquare statistic                   :  157.78
+p-value of test                       :    0.24
+
+
+-----------------------------------------------
+Test on the values of the Statistic J
+
+Number of degrees of freedom          :  500
+ChiSquare statistic                   :  520.28
+p-value of test                       :    0.26
+
+
+-----------------------------------------------
+Test on the values of the Statistic R
+
+Number of degrees of freedom          :  136
+ChiSquare statistic                   :  142.44
+p-value of test                       :    0.34
+
+
+-----------------------------------------------
+Test on the values of the Statistic C
+
+Number of degrees of freedom          :   74
+ChiSquare statistic                   :   75.98
+p-value of test                       :    0.41
+
+
+-----------------------------------------------
+CPU time used                    :  00:02:20.04
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+swalk_RandomWalk1 test:
+-----------------------------------------------
+   N =  1,  n = 1000000,  r =  0,   s = 15,   L0 = 10000,   L1 = 10000
+
+
+
+-----------------------------------------------
+Test on the values of the Statistic H
+
+Number of degrees of freedom          :  384
+ChiSquare statistic                   :  371.24
+p-value of test                       :    0.67
+
+
+-----------------------------------------------
+Test on the values of the Statistic M
+
+Number of degrees of freedom          :  384
+ChiSquare statistic                   :  398.09
+p-value of test                       :    0.30
+
+
+-----------------------------------------------
+Test on the values of the Statistic J
+
+Number of degrees of freedom          : 5000
+ChiSquare statistic                   : 5094.12
+p-value of test                       :    0.17
+
+
+-----------------------------------------------
+Test on the values of the Statistic R
+
+Number of degrees of freedom          :  378
+ChiSquare statistic                   :  322.07
+p-value of test                       :    0.98
+
+
+-----------------------------------------------
+Test on the values of the Statistic C
+
+Number of degrees of freedom          :  200
+ChiSquare statistic                   :  198.56
+p-value of test                       :    0.52
+
+
+-----------------------------------------------
+CPU time used                    :  00:01:46.25
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+swalk_RandomWalk1 test:
+-----------------------------------------------
+   N =  1,  n = 1000000,  r = 15,   s = 15,   L0 = 10000,   L1 = 10000
+
+
+
+-----------------------------------------------
+Test on the values of the Statistic H
+
+Number of degrees of freedom          :  384
+ChiSquare statistic                   :  359.31
+p-value of test                       :    0.81
+
+
+-----------------------------------------------
+Test on the values of the Statistic M
+
+Number of degrees of freedom          :  384
+ChiSquare statistic                   :  344.28
+p-value of test                       :    0.93
+
+
+-----------------------------------------------
+Test on the values of the Statistic J
+
+Number of degrees of freedom          : 5000
+ChiSquare statistic                   : 5013.26
+p-value of test                       :    0.44
+
+
+-----------------------------------------------
+Test on the values of the Statistic R
+
+Number of degrees of freedom          :  378
+ChiSquare statistic                   :  369.10
+p-value of test                       :    0.62
+
+
+-----------------------------------------------
+Test on the values of the Statistic C
+
+Number of degrees of freedom          :  200
+ChiSquare statistic                   :  192.67
+p-value of test                       :    0.63
+
+
+-----------------------------------------------
+CPU time used                    :  00:01:49.34
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+scomp_LinearComp test:
+-----------------------------------------------
+   N =  1,  n = 400020,  r =  0,    s = 1
+
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   12
+Chi2 statistic for size of jumps      :    3.13
+p-value of test                       :    0.9946
+
+
+-----------------------------------------------
+Normal statistic for number of jumps  :   -0.18
+p-value of test                       :    0.57
+
+
+
+-----------------------------------------------
+CPU time used                    :  00:03:35.43
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+scomp_LinearComp test:
+-----------------------------------------------
+   N =  1,  n = 400020,  r = 29,    s = 1
+
+
+
+-----------------------------------------------
+Number of degrees of freedom          :   12
+Chi2 statistic for size of jumps      :   17.04
+p-value of test                       :    0.15
+
+
+-----------------------------------------------
+Normal statistic for number of jumps  :   -0.51
+p-value of test                       :    0.69
+
+
+
+-----------------------------------------------
+CPU time used                    :  00:03:38.04
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+scomp_LempelZiv test:
+-----------------------------------------------
+   N = 10,  n = 134217728,  r =  0,   s =   30,   k =   27
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.12
+p-value of test                       :    0.68
+
+Kolmogorov-Smirnov- statistic = D-    :    0.21
+p-value of test                       :    0.37
+
+Anderson-Darling statistic = A2       :    0.37
+p-value of test                       :    0.88
+
+Tests on the sum of all N observations
+Standardized normal statistic         :   -0.12
+p-value of test                       :    0.55
+
+Sample variance                       :    0.78
+p-value of test                       :    0.63
+
+-----------------------------------------------
+CPU time used                    :  00:01:42.06
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+scomp_LempelZiv test:
+-----------------------------------------------
+   N = 10,  n = 134217728,  r = 15,   s =   15,   k =   27
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.17
+p-value of test                       :    0.49
+
+Kolmogorov-Smirnov- statistic = D-    :    0.14
+p-value of test                       :    0.62
+
+Anderson-Darling statistic = A2       :    0.38
+p-value of test                       :    0.87
+
+Tests on the sum of all N observations
+Standardized normal statistic         :   0.076
+p-value of test                       :    0.47
+
+Sample variance                       :    1.00
+p-value of test                       :    0.44
+
+-----------------------------------------------
+CPU time used                    :  00:01:47.13
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sspectral_Fourier3 test:
+-----------------------------------------------
+   N = 100000,  n = 16384,  r =  0,   s =    3,   k =   14
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    : 5.91e-3
+p-value of test                       :    0.75
+
+Kolmogorov-Smirnov- statistic = D-    :   0.018
+p-value of test                       :    0.07
+
+Anderson-Darling statistic = A2       :    0.92
+p-value of test                       :    0.40
+
+-----------------------------------------------
+CPU time used                    :  00:01:24.95
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sspectral_Fourier3 test:
+-----------------------------------------------
+   N = 100000,  n = 16384,  r = 27,   s =    3,   k =   14
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    : 7.71e-3
+p-value of test                       :    0.61
+
+Kolmogorov-Smirnov- statistic = D-    : 8.55e-3
+p-value of test                       :    0.55
+
+Anderson-Darling statistic = A2       :    0.25
+p-value of test                       :    0.97
+
+-----------------------------------------------
+CPU time used                    :  00:01:25.02
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_LongestHeadRun test:
+-----------------------------------------------
+   N =  1,  n = 1000,  r =  0,   s = 3,   L = 10000020
+
+
+-----------------------------------------------
+Number of degrees of freedom          :    8
+Chi-square statistic                  :   12.04
+p-value of test                       :    0.15
+
+-----------------------------------------------
+Global longest run of 1               :   36.00
+p-value of test                       :    0.07
+
+
+
+-----------------------------------------------
+CPU time used                    :  00:04:26.91
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_LongestHeadRun test:
+-----------------------------------------------
+   N =  1,  n = 1000,  r = 27,   s = 3,   L = 10000020
+
+
+-----------------------------------------------
+Number of degrees of freedom          :    8
+Chi-square statistic                  :   10.91
+p-value of test                       :    0.21
+
+-----------------------------------------------
+Global longest run of 1               :   34.00
+p-value of test                       :    0.25
+
+
+
+-----------------------------------------------
+CPU time used                    :  00:04:28.72
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_PeriodsInStrings test:
+-----------------------------------------------
+   N = 10,  n = 500000000,  r =  0,   s =   10
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.30
+p-value of test                       :    0.13
+
+Kolmogorov-Smirnov- statistic = D-    :    0.12
+p-value of test                       :    0.70
+
+Anderson-Darling statistic = A2       :    1.02
+p-value of test                       :    0.35
+
+Test on the sum of all N observations
+Number of degrees of freedom          :  200
+Chi-square statistic                  :  193.41
+p-value of test                       :    0.62
+
+-----------------------------------------------
+CPU time used                    :  00:07:11.11
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_PeriodsInStrings test:
+-----------------------------------------------
+   N = 10,  n = 500000000,  r = 20,   s =   10
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.20
+p-value of test                       :    0.38
+
+Kolmogorov-Smirnov- statistic = D-    :    0.14
+p-value of test                       :    0.62
+
+Anderson-Darling statistic = A2       :    0.43
+p-value of test                       :    0.82
+
+Test on the sum of all N observations
+Number of degrees of freedom          :  200
+Chi-square statistic                  :  191.26
+p-value of test                       :    0.66
+
+-----------------------------------------------
+CPU time used                    :  00:07:25.75
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_HammingWeight2 test:
+-----------------------------------------------
+   N = 10,  n = 1000000000,  r =  0,   s = 3,   L = 1000000
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.11
+p-value of test                       :    0.73
+
+Kolmogorov-Smirnov- statistic = D-    :    0.19
+p-value of test                       :    0.43
+
+Anderson-Darling statistic = A2       :    0.54
+p-value of test                       :    0.70
+
+Test on the sum of all N observations
+Number of degrees of freedom          : 10000
+Chi-square statistic                  :10106.86
+p-value of test                       :    0.22
+
+-----------------------------------------------
+CPU time used                    :  00:03:42.70
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_HammingWeight2 test:
+-----------------------------------------------
+   N = 10,  n = 1000000000,  r = 27,   s = 3,   L = 1000000
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.34
+p-value of test                       :    0.08
+
+Kolmogorov-Smirnov- statistic = D-    :   0.041
+p-value of test                       :    0.94
+
+Anderson-Darling statistic = A2       :    1.65
+p-value of test                       :    0.14
+
+Test on the sum of all N observations
+Number of degrees of freedom          : 10000
+Chi-square statistic                  : 9764.03
+p-value of test                       :    0.95
+
+-----------------------------------------------
+CPU time used                    :  00:03:49.59
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_HammingCorr test:
+-----------------------------------------------
+   N =  1,  n = 1000000000,  r = 10,   s = 10,   L = 30
+
+
+
+-----------------------------------------------
+Normal statistic                      :   -0.49
+p-value of test                       :    0.69
+
+-----------------------------------------------
+CPU time used                    :  00:03:50.54
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_HammingCorr test:
+-----------------------------------------------
+   N =  1,  n = 100000000,  r = 10,   s = 10,   L = 300
+
+
+
+-----------------------------------------------
+Normal statistic                      :   -0.81
+p-value of test                       :    0.79
+
+-----------------------------------------------
+CPU time used                    :  00:03:44.75
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_HammingCorr test:
+-----------------------------------------------
+   N =  1,  n = 100000000,  r = 10,   s = 10,   L = 1200
+
+
+
+-----------------------------------------------
+Normal statistic                      :    2.27
+p-value of test                       :    0.01
+
+-----------------------------------------------
+CPU time used                    :  00:14:56.88
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_HammingIndep test:
+-----------------------------------------------
+   N = 10,  n = 30000000,  r =  0,   s = 3,   L = 30,   d = 0
+
+
+
+Counters with expected numbers >= 10
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.27
+p-value of test                       :    0.21
+
+Kolmogorov-Smirnov- statistic = D-    :    0.19
+p-value of test                       :    0.43
+
+Anderson-Darling statistic = A2       :    0.88
+p-value of test                       :    0.43
+
+Test on the sum of all N observations
+Number of degrees of freedom          : 4890
+Chi-square statistic                  : 4829.77
+p-value of test                       :    0.73
+
+-----------------------------------------------
+CPU time used                    :  00:06:53.77
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_HammingIndep test:
+-----------------------------------------------
+   N = 10,  n = 30000000,  r = 27,   s = 3,   L = 30,   d = 0
+
+
+
+Counters with expected numbers >= 10
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :   0.070
+p-value of test                       :    0.87
+
+Kolmogorov-Smirnov- statistic = D-    :    0.16
+p-value of test                       :    0.55
+
+Anderson-Darling statistic = A2       :    0.30
+p-value of test                       :    0.94
+
+Test on the sum of all N observations
+Number of degrees of freedom          : 4890
+Chi-square statistic                  : 4931.17
+p-value of test                       :    0.34
+
+-----------------------------------------------
+CPU time used                    :  00:07:04.74
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_HammingIndep test:
+-----------------------------------------------
+   N =  1,  n = 30000000,  r =  0,   s = 4,   L = 300,   d = 0
+
+
+
+Counters with expected numbers >= 10
+-----------------------------------------------
+Number of degrees of freedom          : 4117
+Chi-square statistic                  : 4285.67
+p-value of test                       :    0.03
+
+-----------------------------------------------
+CPU time used                    :  00:05:08.15
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_HammingIndep test:
+-----------------------------------------------
+   N =  1,  n = 30000000,  r = 26,   s = 4,   L = 300,   d = 0
+
+
+
+Counters with expected numbers >= 10
+-----------------------------------------------
+Number of degrees of freedom          : 4117
+Chi-square statistic                  : 4110.83
+p-value of test                       :    0.52
+
+-----------------------------------------------
+CPU time used                    :  00:05:15.70
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_HammingIndep test:
+-----------------------------------------------
+   N =  1,  n = 10000000,  r =  0,   s = 5,   L = 1200,   d = 0
+
+
+
+Counters with expected numbers >= 10
+-----------------------------------------------
+Number of degrees of freedom          : 11825
+Chi-square statistic                  :11788.76
+p-value of test                       :    0.59
+
+-----------------------------------------------
+CPU time used                    :  00:05:33.63
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_HammingIndep test:
+-----------------------------------------------
+   N =  1,  n = 10000000,  r = 25,   s = 5,   L = 1200,   d = 0
+
+
+
+Counters with expected numbers >= 10
+-----------------------------------------------
+Number of degrees of freedom          : 11825
+Chi-square statistic                  :11860.03
+p-value of test                       :    0.41
+
+-----------------------------------------------
+CPU time used                    :  00:05:40.48
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_Run test:
+-----------------------------------------------
+   N =  1,  n = 2000000000,  r =  0,   s =    3
+
+
+-----------------------------------------------
+Total number of 1 runs:  2000000000
+
+Number of degrees of freedom          :   54
+Chi2 statistic for number of runs     :   54.39
+p-value of test                       :    0.46
+
+
+-----------------------------------------------
+Total number of bits:  7999934592
+
+Normal statistic for number of bits   :   -0.52
+p-value of test                       :    0.70
+
+
+
+-----------------------------------------------
+CPU time used                    :  00:04:00.04
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_Run test:
+-----------------------------------------------
+   N =  1,  n = 2000000000,  r = 27,   s =    3
+
+
+-----------------------------------------------
+Total number of 1 runs:  2000000000
+
+Number of degrees of freedom          :   54
+Chi2 statistic for number of runs     :   65.38
+p-value of test                       :    0.14
+
+
+-----------------------------------------------
+Total number of bits:  8000186346
+
+Normal statistic for number of bits   :    1.47
+p-value of test                       :    0.07
+
+
+
+-----------------------------------------------
+CPU time used                    :  00:04:02.91
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_AutoCor test:
+-----------------------------------------------
+   N = 10,  n = 1000000030,  r =  0,   s = 3,   d = 1
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.12
+p-value of test                       :    0.70
+
+Kolmogorov-Smirnov- statistic = D-    :    0.16
+p-value of test                       :    0.55
+
+Anderson-Darling statistic = A2       :    0.29
+p-value of test                       :    0.94
+
+Tests on the sum of all N observations
+Standardized normal statistic         :    0.31
+p-value of test                       :    0.38
+
+Sample variance                       :    1.11
+p-value of test                       :    0.35
+
+-----------------------------------------------
+CPU time used                    :  00:06:38.45
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_AutoCor test:
+-----------------------------------------------
+   N = 10,  n = 1000000029,  r =  0,   s = 3,   d = 3
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.13
+p-value of test                       :    0.66
+
+Kolmogorov-Smirnov- statistic = D-    :    0.18
+p-value of test                       :    0.45
+
+Anderson-Darling statistic = A2       :    0.38
+p-value of test                       :    0.86
+
+Tests on the sum of all N observations
+Standardized normal statistic         :   -0.22
+p-value of test                       :    0.59
+
+Sample variance                       :    0.96
+p-value of test                       :    0.47
+
+-----------------------------------------------
+CPU time used                    :  00:06:23.75
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_AutoCor test:
+-----------------------------------------------
+   N = 10,  n = 1000000030,  r = 27,   s = 3,   d = 1
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.15
+p-value of test                       :    0.58
+
+Kolmogorov-Smirnov- statistic = D-    :    0.12
+p-value of test                       :    0.71
+
+Anderson-Darling statistic = A2       :    0.31
+p-value of test                       :    0.93
+
+Tests on the sum of all N observations
+Standardized normal statistic         :   -0.49
+p-value of test                       :    0.69
+
+Sample variance                       :    0.78
+p-value of test                       :    0.64
+
+-----------------------------------------------
+CPU time used                    :  00:06:41.41
+
+Generator state:
+
+
+
+
+***********************************************************
+HOST = daphnis, Linux
+
+32-bit stdin
+
+
+sstring_AutoCor test:
+-----------------------------------------------
+   N = 10,  n = 1000000029,  r = 27,   s = 3,   d = 3
+
+
+-----------------------------------------------
+
+Kolmogorov-Smirnov+ statistic = D+    :    0.15
+p-value of test                       :    0.59
+
+Kolmogorov-Smirnov- statistic = D-    :    0.27
+p-value of test                       :    0.21
+
+Anderson-Darling statistic = A2       :    0.62
+p-value of test                       :    0.63
+
+Tests on the sum of all N observations
+Standardized normal statistic         :   0.070
+p-value of test                       :    0.47
+
+Sample variance                       :    0.94
+p-value of test                       :    0.49
+
+-----------------------------------------------
+CPU time used                    :  00:06:24.29
+
+Generator state:
+
+
+
+
+
+========= Summary results of BigCrush =========
+
+ Version:          TestU01 1.2.3
+ Generator:        32-bit stdin
+ Number of statistics:  160
+ Total CPU time:   09:48:00.12
+
+ All tests were passed
+
+
+
+Total processed 32Bit Samples =     357100400512
+
+real	1272m18.808s
+user	1587m8.411s
+sys	40m13.751s


### PR DESCRIPTION
Test results for `random-word32-split{,a,s,l}` with SmallCrush.

`random-word32-split` fails badly and `random-word32-splitr` looks iffy. I don't think there is a need to run larger tests on "split" sequences with the `random` package given these failures.