### PR TITLE
Test `Double` randomness with gjrand

### DIFF
--- a/results/random-double-gjrand-huge
+++ b/results/random-double-gjrand-huge
@@ -1,0 +1,172 @@
+$ git rev-parse HEAD
+54fa7f7b5add85495179491896c606e7141e604f
+$ generate random-double | pmcpf --huge
+
+***** PMCPF version 13p --huge *****
+
+
+
+=================
+tri 1/1 (10737418240 bytes)
+========
+blocksize = 64
+lo  var     0.87161; skew     -0.4068; m5    -0.38497;
+mid var     0.21593; skew    -0.68164; m5    -0.91178;
+hi  var     0.28164; skew    -0.45387; m5    -0.18521;
+blocksize = 256
+lo  var     -1.7712; skew    -0.71455; m5    -0.64801;
+mid var    -0.92071; skew     0.67048; m5     0.74249;
+hi  var     -1.0202; skew     0.38193; m5     0.47698;
+blocksize = 1024
+lo  var     -1.7261; skew     0.20828; m5     0.36519;
+mid var     0.74528; skew     0.40828; m5     0.39635;
+hi  var   -0.066431; skew      1.3583; m5      2.0708;
+blocksize = 4096
+lo  var    -0.47238; skew     0.51844; m5      1.5001;    mean    -0.51276;
+mid var       1.518; skew    -0.40336; m5    -0.35866;    mean   -0.040991;
+hi  var     0.52971; skew     0.84435; m5     0.72587;    mean     0.55376;
+
+processed 1.1e+10 numbers in 8.35e+03 seconds. Mon Feb 17 13:55:23 2020
+
+one sided P value (very small numbers are bad)
+P = 0.783
+
+
+=================
+nda8 1/1 (10737418240 bytes)
+========
+extreme = 4.08e-06   (4 12 28 +)
+transform = 4.52   (f 8 41)
+pvals (0.0489 0.0732)
+
+processed 1.1e+10 numbers in 8.35e+03 seconds. Mon Feb 17 13:55:23 2020
+
+one sided P value (very small numbers are bad)
+P = 0.0954
+
+
+=================
+nda4 1/1 (10737418240 bytes)
+========
+extreme = 3.63e-05   (7 2 12 +)
+transform = 3.84   (5 f 14)
+pvals (0.36 0.779)
+
+processed 1.1e+10 numbers in 8.35e+03 seconds. Mon Feb 17 13:55:23 2020
+
+one sided P value (very small numbers are bad)
+P = 0.59
+
+
+=================
+dim3 1/3 (3579139413 bytes)
+========
+counts  =    1.22037 sigma (p = 0.222)
+count   =    4.61063 sigma (p = 0.65) (transformed)
+sums    =   -1.49254 sigma (p = 0.136)
+sum     =    4.62911 sigma (p = 0.618) (transformed)
+abs     =    0.61074 sigma (p = 0.541)
+abs     =    4.83316 sigma (p = 0.297) (transformed)
+
+processed 3.6e+09 numbers in 3.29e+03 seconds. Mon Feb 17 12:31:04 2020
+
+one sided P value (very small numbers are bad)
+P = 0.583
+
+
+=================
+dim56 1/4 (2684354560 bytes)
+========
+sum 1    =    4.61120 sigma (p = 0.65) (transformed)
+abs 1    =    4.69745 sigma (p = 0.499) (transformed)
+sum 2    =    4.60819 sigma (p = 0.655) (transformed)
+abs 2    =    4.48280 sigma (p = 0.855) (transformed)
+
+processed 2.7e+09 numbers in 2.7e+03 seconds. Mon Feb 17 12:21:13 2020
+
+one sided P value (very small numbers are bad)
+P = 0.937
+
+
+=================
+dim155 1/4 (2684354560 bytes)
+========
+counts  =    0.79461 sigma (p = 0.427)
+count  weight =  9  idx = 3ff3d3  p = 0.24 (transformed)
+sums    =    0.55770 sigma (p = 0.577)
+sum    weight =  6  idx = 12210a  p = 0.809 (transformed)
+abs     =   -0.52632 sigma (p = 0.599)
+abs    weight =  5  idx = 024058  p = 0.355 (transformed)
+
+processed 2.7e+09 numbers in 2.7e+03 seconds. Mon Feb 17 12:21:13 2020
+
+one sided P value (very small numbers are bad)
+P = 0.807
+
+
+=================
+diff10 1/4 (2684354560 bytes)
+========
+order = 0 : chis =      16478 ;  p = 0.599352
+order = 1 : chis =      16212 ;  p = 0.345094
+order = 2 : chis =      16419 ;  p = 0.841088
+order = 3 : chis =      16516 ;  p = 0.461575
+order = 4 : chis =      16485 ;  p = 0.570571
+order = 5 : chis =      16239 ;  p = 0.426529
+order = 6 : chis =      16405 ;  p = 0.901317
+order = 7 : chis =      16254 ;  p = 0.477107
+order = 8 : chis =      16379 ;  p = 0.985062
+order = 9 : chis =      16477 ;  p = 0.601937
+
+processed 2.7e+09 numbers in 2.7e+03 seconds. Mon Feb 17 12:21:13 2020
+
+one sided P value (very small numbers are bad)
+P = 0.985
+
+
+=================
+diff3 1/8 (1342177280 bytes)
+========
+chis =       3957  (0.126108)
+chis =       4223  (0.160307)
+chis =       4141  (0.608063)
+chis =       4252  (0.085562)
+chis =       4292  (0.0312008)
+chis =       4010  (0.346194)
+chis =       3996  (0.275328)
+chis =       4166  (0.429649)
+chis =       4190  (0.29579)
+chis =       3872  (0.012385)
+chis =       4062  (0.720711)
+
+processed 1.3e+09 numbers in 1.72e+03 seconds. Mon Feb 17 12:04:48 2020
+
+one sided P value (very small numbers are bad)
+P = 0.128
+
+
+=================
+chi 1/32 (335544320 bytes)
+========
+expected range [ 191 205 227 284 310 331 ]
+      291.78410
+      248.06089
+      262.00569
+      236.27676
+      273.45730
+      279.33243
+
+processed 3.4e+08 numbers in 590 seconds. Mon Feb 17 11:46:00 2020
+
+one sided P value (very small numbers are bad)
+P = 0.512
+
+
+====================
+completed 9 tests
+8 out of 9 tests ok.
+1 grade 1 failures (probably ok).
+
+
+Overall summary one sided P-value (smaller numbers bad)
+P = 0.594 : ok

--- a/results/splitmix-double-gjrand-huge
+++ b/results/splitmix-double-gjrand-huge
@@ -1,0 +1,171 @@
+$ git rev-parse HEAD
+54fa7f7b5add85495179491896c606e7141e604f
+$ generate splitmix-double | pmcpf --huge
+
+***** PMCPF version 13p --huge *****
+
+
+
+=================
+tri 1/1 (10737418240 bytes)
+========
+blocksize = 64
+lo  var     -1.2047; skew    -0.49082; m5    -0.63752;
+mid var    -0.64384; skew     0.34248; m5    -0.12159;
+hi  var    -0.45712; skew     0.28485; m5     0.13705;
+blocksize = 256
+lo  var    0.060985; skew     0.40958; m5     0.72509;
+mid var    -0.55371; skew     0.10665; m5    -0.60246;
+hi  var    -0.20111; skew     0.32485; m5       0.736;
+blocksize = 1024
+lo  var     0.79469; skew   -0.087822; m5    -0.32346;
+mid var     -0.7846; skew      -1.807; m5     -2.4152;
+hi  var      -1.747; skew     0.18647; m5     0.19685;
+blocksize = 4096
+lo  var    -0.17114; skew     -1.6694; m5     -2.3802;    mean     -0.2963;
+mid var   -0.003749; skew     0.34146; m5     -0.1296;    mean     0.31329;
+hi  var    -0.45338; skew    -0.34375; m5    -0.26994;    mean   -0.016998;
+
+processed 1.1e+10 numbers in 1.66e+03 seconds. Mon Feb 17 12:04:06 2020
+
+one sided P value (very small numbers are bad)
+P = 0.461
+
+
+=================
+nda8 1/1 (10737418240 bytes)
+========
+extreme = 0.000114   (5 2 18 -)
+transform = 4.4   (c 6 18)
+pvals (0.754 0.122)
+
+processed 1.1e+10 numbers in 1.66e+03 seconds. Mon Feb 17 12:04:06 2020
+
+one sided P value (very small numbers are bad)
+P = 0.229
+
+
+=================
+nda4 1/1 (10737418240 bytes)
+========
+extreme = 0.000134   (11 2 17 -)
+transform = 3.5   (b 5 17)
+pvals (0.808 0.997)
+
+processed 1.1e+10 numbers in 1.66e+03 seconds. Mon Feb 17 12:04:06 2020
+
+one sided P value (very small numbers are bad)
+P = 0.963
+
+
+=================
+dim3 1/3 (3579139413 bytes)
+========
+counts  =   -1.76239 sigma (p = 0.078)
+count   =    4.47818 sigma (p = 0.86) (transformed)
+sums    =   -0.19985 sigma (p = 0.842)
+sum     =    4.50946 sigma (p = 0.818) (transformed)
+abs     =    0.69549 sigma (p = 0.487)
+abs     =    4.69141 sigma (p = 0.509) (transformed)
+
+processed 3.6e+09 numbers in 840 seconds. Mon Feb 17 11:50:24 2020
+
+one sided P value (very small numbers are bad)
+P = 0.386
+
+
+=================
+dim56 1/4 (2684354560 bytes)
+========
+sum 1    =    4.32135 sigma (p = 0.983) (transformed)
+abs 1    =    4.72167 sigma (p = 0.458) (transformed)
+sum 2    =    4.50772 sigma (p = 0.821) (transformed)
+abs 2    =    4.76435 sigma (p = 0.391) (transformed)
+
+processed 2.7e+09 numbers in 713 seconds. Mon Feb 17 11:48:17 2020
+
+one sided P value (very small numbers are bad)
+P = 0.863
+
+
+=================
+dim155 1/4 (2684354560 bytes)
+========
+counts  =    0.69203 sigma (p = 0.489)
+count  weight =  5  idx = 300244  p = 0.665 (transformed)
+sums    =    0.92340 sigma (p = 0.356)
+sum    weight =  5  idx = 088884  p = 0.138 (transformed)
+abs     =    0.18635 sigma (p = 0.852)
+abs    weight =  2  idx = 000104  p = 0.611 (transformed)
+
+processed 2.7e+09 numbers in 713 seconds. Mon Feb 17 11:48:17 2020
+
+one sided P value (very small numbers are bad)
+P = 0.59
+
+
+=================
+diff10 1/4 (2684354560 bytes)
+========
+order = 0 : chis =      16684 ;  p = 0.0976334
+order = 1 : chis =      16222 ;  p = 0.375055
+order = 2 : chis =      16403 ;  p = 0.908443
+order = 3 : chis =      16459 ;  p = 0.67098
+order = 4 : chis =      16538 ;  p = 0.390488
+order = 5 : chis =      16393 ;  p = 0.955123
+order = 6 : chis =      16002 ;  p = 0.0344139
+order = 7 : chis =      16418 ;  p = 0.844735
+order = 8 : chis =      16108 ;  p = 0.127433
+order = 9 : chis =      16635 ;  p = 0.165085
+
+processed 2.7e+09 numbers in 713 seconds. Mon Feb 17 11:48:17 2020
+
+one sided P value (very small numbers are bad)
+P = 0.295
+
+
+=================
+diff3 1/8 (1342177280 bytes)
+========
+chis =       3925  (0.0582853)
+chis =       4138  (0.631844)
+chis =       4025  (0.442111)
+chis =       4024  (0.433201)
+chis =       3928  (0.062673)
+chis =       4055  (0.66032)
+chis =       4015  (0.380063)
+chis =       4091  (0.972171)
+chis =       4057  (0.682482)
+chis =       4183  (0.32949)
+chis =       4221  (0.166616)
+
+processed 1.3e+09 numbers in 377 seconds. Mon Feb 17 11:42:41 2020
+
+one sided P value (very small numbers are bad)
+P = 0.483
+
+
+=================
+chi 1/32 (335544320 bytes)
+========
+expected range [ 191 205 227 284 310 331 ]
+      229.54219
+      252.67078
+      238.42159
+      234.63602
+      269.15045
+      281.78273
+
+processed 3.4e+08 numbers in 69 seconds. Mon Feb 17 11:37:33 2020
+
+one sided P value (very small numbers are bad)
+P = 0.807
+
+
+====================
+completed 9 tests
+9 out of 9 tests ok.
+
+
+Overall summary one sided P-value (smaller numbers bad)
+P = 0.904 : ok


### PR DESCRIPTION
For `splitmix` we get:
```
Overall summary one sided P-value (smaller numbers bad)
P = 0.904 : ok
```

For `random` we get:
```
Overall summary one sided P-value (smaller numbers bad)
P = 0.594 : ok
```